### PR TITLE
Add configure() to deal with how Widows manages class variables with multiprocessing

### DIFF
--- a/src/neuronumba/simulator/models/model.py
+++ b/src/neuronumba/simulator/models/model.py
@@ -1,3 +1,4 @@
+import os
 from enum import IntEnum
 
 import numba as nb
@@ -26,6 +27,12 @@ class Model(HasAttr):
         super().__init__(**kwargs)
         cls = type(self)
         setattr(cls, 'P', cls._build_parameter_enum())
+
+    def configure(self, **kwargs):
+        if os.name == "nt":
+            cls = type(self)
+            setattr(cls, 'P', cls._build_parameter_enum())
+        super().configure(**kwargs)
 
     def _init_dependant(self):
         self.n_rois = self.weights.shape[0]


### PR DESCRIPTION
Windows does not copy class variables created dynamically when spawning new processes, so enum P has to be re-created in the configure() step to ensure it is initialized. Not the optimal solution, so ideas are wellcome.