### PR TITLE
Fix: use np.zeros instead of np.empty

### DIFF
--- a/src/neuronumba/simulator/integrators/euler.py
+++ b/src/neuronumba/simulator/integrators/euler.py
@@ -33,7 +33,7 @@ class EulerStochastic(Integrator):
 
     def get_numba_scheme(self, dfun):
         dt = self.dt
-        stimulus = np.empty((1, 1))
+        stimulus = np.zeros((1, 1))
         sigmas = self.sigmas
         sqrt_dt = self._sqrt_dt
 


### PR DESCRIPTION
Using np.empty meant that the contents of stimulus could be random, producing wrong results in the integration when using a single region (very unlikely scenario)