### PR TITLE
Fix/Improvements in FitGEC & filterps

### DIFF
--- a/src/neuronumba/fitting/gec/fitting_gec.py
+++ b/src/neuronumba/fitting/gec/fitting_gec.py
@@ -23,15 +23,6 @@ from neuronumba.observables.linear.linearfc import LinearFC
 from neuronumba.tools import filterps
 from neuronumba.simulator.models import Model
 
-def calc_H_freq(all_HC_fMRI, N, Tmax, TR, bpf):
-    baseline_ts = np.zeros((len(all_HC_fMRI), N, Tmax))
-    for n, subj in enumerate(all_HC_fMRI):
-        baseline_ts[n] = all_HC_fMRI[subj]
-
-    # -------------------------- Setup Hopf
-    f_diff = filterps.filt_pow_spetra_multiple_subjects(baseline_ts, TR, bpf)
-    return 2 * np.pi * f_diff  # omega
-
 class FitGEC(HasAttr):
     tau = Attr(default=1.0)
     g = Attr(default=1.0)
@@ -185,6 +176,16 @@ class FitGEC(HasAttr):
             for j in range(cov.shape[1]):
                 sr[i,j] = 1/np.sqrt(abs(cov[i,i]))/np.sqrt(abs(cov[j,j]))
         return sr
+
+    @staticmethod
+    def calc_H_freq(all_HC_fMRI, N, Tmax, TR, bpf, version=filterps.FiltPowSpetraVersion.v2021):
+        baseline_ts = np.zeros((len(all_HC_fMRI), Tmax, N))
+        for n, subj in enumerate(all_HC_fMRI):
+            baseline_ts[n] = all_HC_fMRI[subj]
+
+        # -------------------------- Setup Hopf
+        f_diff = filterps.filt_pow_spetra_multiple_subjects(baseline_ts, TR, bpf, version)
+        return 2 * np.pi * f_diff  # omega
 
     # --------------- fit gEC
     def fitGEC(

--- a/src/neuronumba/fitting/gec/fitting_gec.py
+++ b/src/neuronumba/fitting/gec/fitting_gec.py
@@ -178,13 +178,23 @@ class FitGEC(HasAttr):
         return sr
 
     @staticmethod
-    def calc_H_freq(all_HC_fMRI, N, Tmax, TR, bpf, version=filterps.FiltPowSpetraVersion.v2021):
-        baseline_ts = np.zeros((len(all_HC_fMRI), Tmax, N))
-        for n, subj in enumerate(all_HC_fMRI):
-            baseline_ts[n] = all_HC_fMRI[subj]
+    def calc_H_freq(all_HC_fMRI, TR, bpf, version=filterps.FiltPowSpetraVersion.v2021):
+        """
+        Compute H freq for each node. 
+        
+        Parameters
+        ----------
+        all_HC_fMRI: The fMRI of the "health control" group. Can be given in a dictionaray format, 
+                     or in an array format
+        TR: Tr in milliseconds
+        bpf: BandPassFilter to apply
+        version: Version of FiltPowSpectra to use
 
-        # -------------------------- Setup Hopf
-        f_diff = filterps.filt_pow_spetra_multiple_subjects(baseline_ts, TR, bpf, version)
+        Returns
+        -------
+        The h frequencies for each node
+        """
+        f_diff = filterps.filt_pow_spetra_multiple_subjects(all_HC_fMRI, TR, bpf, version)
         return 2 * np.pi * f_diff  # omega
 
     # --------------- fit gEC

--- a/src/neuronumba/fitting/gec/fitting_gec.py
+++ b/src/neuronumba/fitting/gec/fitting_gec.py
@@ -21,30 +21,7 @@ from scipy.linalg import expm
 from neuronumba.basic.attr import HasAttr, Attr
 from neuronumba.observables.linear.linearfc import LinearFC
 from neuronumba.tools import filterps
-
-# time lagged covariance without SC
-def calc_COV_emp(tss, timelag = 1):
-    """
-    wo = without SC mask
-    
-    Parameters
-    ----------
-    tss : non-perturbed timeseries, in format (n_roi, n_timesteps)
-    timelag : the number of timesteps of your timelag, default = 1
-    
-    Returns
-    -------
-    time-lagged cov matrix in format(n_roi, n_roi)
-    """
-    n_roi = tss.shape[0]
-    EC    = np.zeros((n_roi,n_roi))
-    for i in range(n_roi):
-        for j in range(n_roi):
-            correlation = signal.correlate(tss[i,:] - tss[i,:].mean(), tss[j,:] - tss[j,:].mean(), mode = 'full')
-            lags        = signal.correlation_lags(tss[i,:].shape[0], tss[j,:].shape[0], mode = 'full')
-            EC[i,j]     = correlation[lags == timelag] / tss.shape[1]
-    return EC
-
+from neuronumba.simulator.models import Model
 
 def calc_H_freq(all_HC_fMRI, N, Tmax, TR, bpf):
     baseline_ts = np.zeros((len(all_HC_fMRI), N, Tmax))
@@ -54,73 +31,6 @@ def calc_H_freq(all_HC_fMRI, N, Tmax, TR, bpf):
     # -------------------------- Setup Hopf
     f_diff = filterps.filt_pow_spetra_multiple_subjects(baseline_ts, TR, bpf)
     return 2 * np.pi * f_diff  # omega
-
-
-def update_EC(
-    eps_fc, 
-    eps_cov, 
-    FCemp, 
-    FCsim, 
-    covemp, 
-    covsim, 
-    SC, 
-    only_positive=True,
-    maxC=0.2):
-    """
-    Parameters
-    ----------
-    eps_fc   : parameter, float
-    eps_cov  : parameter, float
-    FCemp    : empirical functional connectivity, format (n_roi, n_roi)
-    FCsim    : simulated functional connectivity, format (n_roi, n_roi)
-    covemp   : empirical effective connectivity, format (n_roi, n_roi)
-    covsim   : simulated effective connectivity, format (n_roi, n_roi)
-    SC       : structural connectivity, format (n_roi, n_roi)
-    only_positive : default = True, to keep the update of the SC in positive values
-    maxC     : Scaling of the SCnew matrix
-            
-    Returns
-    -------
-    An updated SC, format (n_roi, n_roi)
-
-    """
-    n_roi = SC.shape[0]
-                    
-    SCnew = SC + eps_fc * (FCemp - FCsim) + eps_cov * (covemp - covsim)
-    for i in range(n_roi):
-        for j in range(n_roi):
-            if SC[i,j] == 0:
-                SCnew[i,j] = 0
-    if only_positive == True:
-        SCnew[SCnew < 0] = 0
-    SCnew /= np.max(abs(SCnew))
-    SCnew *= maxC
-
-    return SCnew
-
-
-def calc_sigratio(cov):
-    """
-    The calc_sigratio function calculates the normalization factor for the 
-    time-lagged covariance matrix. This is used so that the FC, which is a 
-    covariance normalized by the standard deviations of the two parts, and the 
-    tauCOV are in the same space, dimensionless. 
-    
-    Parameters
-    ----------
-    cov : tss put through calc_EC, format (n_roi,n_roi)
-
-    Returns
-    -------
-    sigratios in format (n_roi,n_roi)
-
-    """     
-    sr = np.zeros((cov.shape))        
-    for i in range(cov.shape[0]):
-        for j in range(cov.shape[1]):
-            sr[i,j] = 1/np.sqrt(abs(cov[i,i]))/np.sqrt(abs(cov[j,j]))
-    return sr
-
 
 class FitGEC(HasAttr):
     tau = Attr(default=1.0)
@@ -185,8 +95,119 @@ class FitGEC(HasAttr):
         f"***************************************************************************"
         )
 
+    # time lagged covariance without SC
+    # CAUTION! tss is in (n_roi, time) format
+    @staticmethod
+    def _calc_COV_emp(tss: np.ndarray, timelag: int = 1):
+        """
+        wo = without SC mask
+        
+        Parameters
+        ----------
+        tss : non-perturbed timeseries, in format (n_roi, n_timesteps)
+        timelag : the number of timesteps of your timelag, default = 1
+        
+        Returns
+        -------
+        time-lagged cov matrix in format(n_roi, n_roi)
+        """
+        n_roi = tss.shape[0]
+        EC    = np.zeros((n_roi,n_roi))
+        for i in range(n_roi):
+            for j in range(n_roi):
+                correlation = signal.correlate(tss[i,:] - tss[i,:].mean(), tss[j,:] - tss[j,:].mean(), mode = 'full')
+                lags        = signal.correlation_lags(tss[i,:].shape[0], tss[j,:].shape[0], mode = 'full')
+                EC[i,j]     = correlation[lags == timelag] / tss.shape[1]
+        return EC
+
+    @staticmethod
+    def _update_EC(
+        eps_fc: float, 
+        eps_cov: float, 
+        FCemp: np.ndarray, 
+        FCsim: np.ndarray, 
+        covemp: np.ndarray, 
+        covsim: np.ndarray, 
+        SC: np.ndarray, 
+        only_positive: bool = True,
+        maxC: float = 0.2):
+        """
+        Parameters
+        ----------
+        eps_fc   : parameter, float
+        eps_cov  : parameter, float
+        FCemp    : empirical functional connectivity, format (n_roi, n_roi)
+        FCsim    : simulated functional connectivity, format (n_roi, n_roi)
+        covemp   : empirical effective connectivity, format (n_roi, n_roi)
+        covsim   : simulated effective connectivity, format (n_roi, n_roi)
+        SC       : structural connectivity, format (n_roi, n_roi)
+        only_positive : default = True, to keep the update of the SC in positive values
+        maxC     : Scaling of the SCnew matrix
+                
+        Returns
+        -------
+        An updated SC, format (n_roi, n_roi)
+
+        """
+        n_roi = SC.shape[0]
+                        
+        SCnew = SC + eps_fc * (FCemp - FCsim) + eps_cov * (covemp - covsim)
+        for i in range(n_roi):
+            for j in range(n_roi):
+                if SC[i,j] == 0:
+                    SCnew[i,j] = 0
+        if only_positive == True:
+            SCnew[SCnew < 0] = 0
+        SCnew /= np.max(abs(SCnew))
+        SCnew *= maxC
+
+        return SCnew
+
+    @staticmethod
+    def _calc_sigratio(cov: np.ndarray):
+        """
+        The calc_sigratio function calculates the normalization factor for the 
+        time-lagged covariance matrix. This is used so that the FC, which is a 
+        covariance normalized by the standard deviations of the two parts, and the 
+        tauCOV are in the same space, dimensionless. 
+        
+        Parameters
+        ----------
+        cov : tss put through calc_EC, format (n_roi,n_roi)
+
+        Returns
+        -------
+        sigratios in format (n_roi,n_roi)
+
+        """     
+        sr = np.zeros((cov.shape))        
+        for i in range(cov.shape[0]):
+            for j in range(cov.shape[1]):
+                sr[i,j] = 1/np.sqrt(abs(cov[i,i]))/np.sqrt(abs(cov[j,j]))
+        return sr
+
     # --------------- fit gEC
-    def fitGEC(self, timeseries, FC_emp, starting_SC, model, TR):
+    def fitGEC(
+        self, 
+        timeseries: np.ndarray, 
+        FC_emp: np.ndarray, 
+        starting_SC: np.ndarray, 
+        model: Model, 
+        TR: float
+    ):
+        """
+        Parameters:
+            timeseries (matrix 2D): Empirical timeseries data in the format of: (time, regions)
+            FC_emp (matrix 2D): Empirical functional connectivity.
+            starting_SC (matrix 2D): Starting structural connectivity.
+            model: linearized model to use
+            TR (float): Repetition time in milliseconds.
+        """
+
+        # All the computations inside GEC are performed in the (regions, time) timeseries format. 
+        # So convert it before anything else:
+        timeseries = timeseries.T
+
         # Runtime
         start_time = time.time()
 
@@ -202,10 +223,10 @@ class FitGEC(HasAttr):
         # We need two empirical coveriances computed from the timeseries. The non-lag for the computation of the 
         # sigratio and the Tau lagged for GEC computation. 
         COV_emp = np.cov(timeseries)
-        COV_emp_tau = calc_COV_emp(timeseries, timelag=self.tau)
+        COV_emp_tau = FitGEC._calc_COV_emp(timeseries, timelag=self.tau)
     
         # Scaling factors based on the empirical covariance matrices
-        sigrat_emp = calc_sigratio(COV_emp)
+        sigrat_emp = FitGEC._calc_sigratio(COV_emp)
 
         # Initializing SC matrix
         newSC = starting_SC
@@ -228,23 +249,24 @@ class FitGEC(HasAttr):
             #   COV_sim: simulatied covaraiance matrix
             #   COVsimtotal: total simulated covariance matrix
             #   A: the Jacobian matrix
-            A, Qn = model.compute_linear_matrix(newSC, self.sigma)
+            A = model.get_jacobian(newSC)
+            Qn = model.get_noise_matrix(self.sigma, len(newSC))
             obs = LinearFC()
             result =  obs.from_matrix(A, Qn)
             FC_sim = result['FC']
             COVsimtotal = result['CVth']
             COV_sim = result['CV']
 
-            sigrat_sim = calc_sigratio(COV_sim)  # scaling factor based on the simulated covariance matrix
-            COV_sim_tau = np.matmul(expm((self.tau * TR) * A), COVsimtotal)  # total simulated covariance at time lag Tau
+            sigrat_sim = FitGEC._calc_sigratio(COV_sim)  # scaling factor based on the simulated covariance matrix
+            COV_sim_tau = np.matmul(expm((self.tau * (TR / 1000.0)) * A), COVsimtotal)  # total simulated covariance at time lag Tau
             COV_sim_tau = COV_sim_tau[0:n_roi, 0:n_roi]  # simulated covariance at time lag Tau (nodes of interest)
 
             # adjust the arguments eps_fc and eps_cov to change the updating of the
             # weights in the gEC depending on the difference between the empirical and
             # simulated FC and time-lagged covariance
-            newSC = update_EC(eps_fc=self.eps_fc, eps_cov=self.eps_cov, FCemp=FC_emp,
-                            FCsim=FC_sim, covemp=sigrat_emp * COV_emp_tau,
-                            covsim=sigrat_sim * COV_sim_tau, SC=newSC)
+            newSC = FitGEC._update_EC(  eps_fc=self.eps_fc, eps_cov=self.eps_cov, FCemp=FC_emp,
+                                        FCsim=FC_sim, covemp=sigrat_emp * COV_emp_tau,
+                                        covsim=sigrat_sim * COV_sim_tau, SC=newSC)
 
             # Compute errors for this iteration. We saved them for debbuging and such
             self.last_run_convergence_err_FC[i] = np.mean((FC_emp - FC_sim) ** 2)

--- a/src/neuronumba/fitting/gec/fitting_gec.py
+++ b/src/neuronumba/fitting/gec/fitting_gec.py
@@ -13,6 +13,7 @@
 from email.policy import default
 import warnings
 import time
+from typing import Union
 
 import numpy as np
 from scipy import signal
@@ -22,6 +23,7 @@ from neuronumba.basic.attr import HasAttr, Attr
 from neuronumba.observables.linear.linearfc import LinearFC
 from neuronumba.tools import filterps
 from neuronumba.simulator.models import Model
+from neuronumba.tools.filters import BandPassFilter
 
 class FitGEC(HasAttr):
     tau = Attr(default=1.0)
@@ -178,14 +180,19 @@ class FitGEC(HasAttr):
         return sr
 
     @staticmethod
-    def calc_H_freq(all_HC_fMRI, TR, bpf, version=filterps.FiltPowSpetraVersion.v2021):
+    def calc_H_freq(
+        all_HC_fMRI: Union[np.ndarray, dict], 
+        TR: float, 
+        bpf: BandPassFilter, 
+        version: filterps.FiltPowSpetraVersion=filterps.FiltPowSpetraVersion.v2021
+    ):
         """
         Compute H freq for each node. 
         
         Parameters
         ----------
         all_HC_fMRI: The fMRI of the "health control" group. Can be given in a dictionaray format, 
-                     or in an array format
+                     or in an array format (subject, time, node)
         TR: Tr in milliseconds
         bpf: BandPassFilter to apply
         version: Version of FiltPowSpectra to use

--- a/src/neuronumba/fitting/gec/fitting_gec.py
+++ b/src/neuronumba/fitting/gec/fitting_gec.py
@@ -45,7 +45,7 @@ class FitGEC(HasAttr):
 
     def last_run_debug_printing(self):
         """
-        Helper function to nicely print debug on terminal last computation information.
+        Helper function to nicely print debug last computation information on terminal.
         """
         
         if self.last_run_reason_of_termination == "":
@@ -182,8 +182,7 @@ class FitGEC(HasAttr):
     @staticmethod
     def calc_H_freq(
         all_HC_fMRI: Union[np.ndarray, dict], 
-        TR: float, 
-        bpf: BandPassFilter, 
+        tr: float, 
         version: filterps.FiltPowSpetraVersion=filterps.FiltPowSpetraVersion.v2021
     ):
         """
@@ -192,16 +191,16 @@ class FitGEC(HasAttr):
         Parameters
         ----------
         all_HC_fMRI: The fMRI of the "health control" group. Can be given in a dictionaray format, 
-                     or in an array format (subject, time, node)
-        TR: Tr in milliseconds
-        bpf: BandPassFilter to apply
+                     or in an array format (subject, time, node).
+                     NOTE: that the signals must already be filitered. 
+        tr: TR in milliseconds
         version: Version of FiltPowSpectra to use
 
         Returns
         -------
         The h frequencies for each node
         """
-        f_diff = filterps.filt_pow_spetra_multiple_subjects(all_HC_fMRI, TR, bpf, version)
+        f_diff = filterps.filt_pow_spetra_multiple_subjects(all_HC_fMRI, tr, version)
         return 2 * np.pi * f_diff  # omega
 
     # --------------- fit gEC
@@ -235,7 +234,7 @@ class FitGEC(HasAttr):
         if not np.allclose(np.diag(starting_SC), 0):
             warnings.warn("Not all diagonal elemnts in starting_SC are zero.")
 
-        # ------- number or RoIs
+        # number or RoIs
         n_roi = np.shape(starting_SC)[0]
 
         # We need two empirical coveriances computed from the timeseries. The non-lag for the computation of the 
@@ -315,8 +314,3 @@ class FitGEC(HasAttr):
         self.last_run_compute_time_sec = time.time() - start_time
         
         return save_SC
-
-
-# ================================================================================================================
-# ================================================================================================================
-# ================================================================================================================EOF

--- a/src/neuronumba/observables/fdt.py
+++ b/src/neuronumba/observables/fdt.py
@@ -30,7 +30,8 @@ class FDT(Observable):
         n_roi = np.shape(self.eff_con)[0]
         n2 = 2 * n_roi
         
-        A, Qn = self.model.compute_linear_matrix(self.eff_con, self.sigma)
+        A = self.model.get_jacobian(self.eff_con)
+        Qn = self.model.get_noise_matrix(self.sigma, len(self.eff_con))
         obs = LinearFC()
         result =  obs.from_matrix(A, Qn)
         FC_sim = result['FC']

--- a/src/neuronumba/observables/linear/linearfc.py
+++ b/src/neuronumba/observables/linear/linearfc.py
@@ -3,15 +3,12 @@ from scipy import linalg
 
 from neuronumba.basic.attr import HasAttr, Attr
 from neuronumba.observables.base_observable import Observable
-from neuronumba.tools.matlab_tricks import correlation_from_covariance
-
-# Necessary if using the "slycot" versions of the solver
-# import control
-# import numpy as np
+from neuronumba.tools.matlab_tricks import correlation_from_covariance, lyap
 
 class LinearFC(Observable):
     A = Attr(default=None)
     Qn = Attr(default=None)
+    lyap_method = Attr(default='slycot') # Current methods are ‘slycot’ and ‘scipy’.
 
     def from_matrix(self, A, Qn):
         self.A = A
@@ -45,14 +42,7 @@ class LinearFC(Observable):
 
         N = int(self.A.shape[0] / 2)
         # Solves the Lyapunov equation: A*X + X*Ah = Q, with Ah the conjugate transpose of A
-        CVth = linalg.solve_continuous_lyapunov(self.A, -self.Qn)
-
-        # There are two other options to compute the solution to the equation, using the same slycot library under matlab implementation.
-        # A) Using the lyap "sylvester" version. Under the hood is calling slycot function "sb04md"
-        # Aconjtrans = np.atleast_2d(self.A).T.conj()
-        # CVth = control.lyap(self.A, Aconjtrans, self.Qn, method='slycot')
-        # B) Using the lyap "lyapunov" version. Under the hood is calling slycot function "sb03md"
-        # CVth = control.lyap(self.A, self.Qn, method='slycot')
+        CVth = lyap(self.A, self.Qn, method=self.lyap_method)
 
         # simulated FC
         FCth = correlation_from_covariance(CVth)

--- a/src/neuronumba/tools/filterps.py
+++ b/src/neuronumba/tools/filterps.py
@@ -11,8 +11,8 @@ from enum import Enum
 from neuronumba.tools.filters import BandPassFilter
 
 class FiltPowSpetraVersion(Enum):
-    v2021 = "v2021"
-    v2015 = "v2015"
+    v2021 = "v2021" # This is now the default one (from Irene's code)
+    v2015 = "v2015" # This was the original version implemented (from Victor Saenger code)
 
 def conv(u: np.ndarray, v: np.ndarray):  # python equivalent to matlab conv 'same' method
     # from https://stackoverflow.com/questions/38194270/matlab-convolution-same-to-numpy-convolve

--- a/src/neuronumba/tools/filterps.py
+++ b/src/neuronumba/tools/filterps.py
@@ -49,71 +49,55 @@ def gaussfilt(t, z, sigma):
 
     return zfilt
 
-
 def filt_pow_spetra(signal, TR, bpf):
-    nNodes, Tmax = signal.shape  # Here we are assuming we receive only ONE subject...
-    # idxMinFreq = np.argmin(np.abs(freqs-0.04))
-    # idxMaxFreq = np.argmin(np.abs(freqs-0.07))
-    # nFreqs = freqs.size
-
-    # delt = 2                                   # sampling interval
-    # fnq = 1/(2*delt)                           # Nyquist frequency
-    # k = 2                                      # 2nd order butterworth filter
-
-    # =================== WIDE BANDPASS
-    # flp = .04                                  # lowpass frequency of filter
-    # fhi = fnq-0.001  #.249                     # highpass needs to be limited by Nyquist frequency, which in turn depends on TR
-    # ts_filt_wide =zscore(filtfilt(bfilt_wide,afilt_wide,x))
-    # pw_filt_wide = abs(fft(ts_filt_wide))
-    # PowSpect_filt_wide(:,seed) = pw_filt_wide[1:np.floor(TT/2)] ** 2 / (TT/2)
-
-    # =================== NARROW LOW BANDPASS
-    # print(f'BOLD Filters: low={BOLDFilters.flp}, hi={BOLDFilters.fhi}')
-    # ts_filt_narrow = zscore(BOLDFilters.BandPassFilter(signal, removeStrongArtefacts=False), axis=0)  # Here we used the zscore to "normalize" the values... not really needed, but makes things easier to follow! ;-)
-    # TODO: move all shapes to (n_time_samples, n_rois)
-    ts_filt_narrow = bpf.filter(signal.T).T
-    pw_filt_narrow = np.abs(np.fft.fft(ts_filt_narrow, axis=1))
-    PowSpect_filt_narrow = pw_filt_narrow[:, 0:int(np.floor(Tmax / 2))].T ** 2 / (Tmax / TR)
-
-    # Power_Areas_filt_narrow_unsmoothed = PowSpect_filt_narrow  # By now, do nothing...
+    """
+    signal: Time series of shape (time, regions)
+    TR: Repetition time
+    bpf: Bandpass filter
+    """
+    
+    tmax, nNodes = signal.shape  # Updated shape to (time, regions)
+    
+    # Apply bandpass filtering (signal is now time x regions)
+    ts_filt_narrow = bpf.filter(signal)
+    
+    # Perform FFT along time dimension (axis=0)
+    pw_filt_narrow = np.abs(np.fft.fft(ts_filt_narrow, axis=0))
+    
+    # Get the power spectrum for the first half of frequencies
+    # We take slices up to tmax/2 from the first dimension (time)
+    PowSpect_filt_narrow = pw_filt_narrow[0:int(np.floor(tmax / 2)), :].T ** 2 / (tmax / (TR / 1000.0))
+    
     return PowSpect_filt_narrow
-
 
 def filt_pow_spetra_multiple_subjects(signal, tr, bpf):
     if type(signal) is dict:
         n_subjects = len(signal.keys())
-        n_nodes, tmax = next(iter(signal.values())).shape
+        tmax, n_nodes = next(iter(signal.values())).shape
         PowSpect_filt_narrow = np.zeros((n_subjects, n_nodes, int(np.floor(tmax / 2))))
         for i, s in enumerate(signal.keys()):
-            PowSpect_filt_narrow[i] = filt_pow_spetra(signal[s][:, :tmax], tr, bpf).T
+            # Transpose signal to match expected input for filt_pow_spetra
+            PowSpect_filt_narrow[i] = filt_pow_spetra(signal[s][:tmax, :], tr, bpf).T
         Power_Areas_filt_narrow_unsmoothed = np.mean(PowSpect_filt_narrow, axis=0).T
     elif signal.ndim == 2:
         n_subjects = 1
-        n_nodes, tmax = signal.shape  # Here we are assuming we receive only ONE subject...
-        Power_Areas_filt_narrow_unsmoothed = filt_pow_spetra(signal, tr)
+        tmax, n_nodes = signal.shape # Here we are assuming we receive only ONE subject...
+        Power_Areas_filt_narrow_unsmoothed = filt_pow_spetra(signal, tr, bpf).T
     else:
         # In case we receive more than one subject, we do a mean...
-        n_subjects, n_nodes, tmax = signal.shape
+        n_subjects, tmax, n_nodes = signal.shape
         PowSpect_filt_narrow = np.zeros((n_subjects, n_nodes, int(np.floor(tmax / 2))))
         for s in range(n_subjects):
+            # Now signal shape is [subject, time, regions]
             PowSpect_filt_narrow[s] = filt_pow_spetra(signal[s, :, :], tr, bpf).T
         Power_Areas_filt_narrow_unsmoothed = np.mean(PowSpect_filt_narrow, axis=0).T
-        # Power_Areas_filt_wide_unsmoothed = mean(PowSpect_filt_wide,3);
-
+    
     Power_Areas_filt_narrow_smoothed = np.zeros_like(Power_Areas_filt_narrow_unsmoothed)
-    # Power_Areas_filt_wide_smoothed = zeros(nFreqs, nNodes);
-    # vsig = zeros(1, nNodes);
-    Ts = tmax * tr
+    Ts = tmax * (tr / 1000.0)
     freqs = np.arange(0, tmax / 2 - 1) / Ts
     for seed in np.arange(n_nodes):
         Power_Areas_filt_narrow_smoothed[:, seed] = gaussfilt(freqs, Power_Areas_filt_narrow_unsmoothed[:, seed], 0.01)
-        # Power_Areas_filt_wide_smoothed(:,seed)=gaussfilt(freq,Power_Areas_filt_wide_unsmoothed(:,seed)',0.01);
-
-        # relative power in frequencies of interest (.04 - .07 Hz) with respect
-        # to entire power of bandpass-filtered data (.04 - just_below_nyquist)
-        #  vsig(seed) =...
-        #         sum(Power_Areas_filt_wide_smoothed(idxMinFreq:idxMaxFreq,seed))/sum(Power_Areas_filt_wide_smoothed(:,seed));
-
+    
     # a-minimization seems to only work if we use the indices for frequency of
     # maximal power from the narrowband-smoothed data
     idxFreqOfMaxPwr = np.argmax(Power_Areas_filt_narrow_smoothed, axis=0)

--- a/src/neuronumba/tools/filterps.py
+++ b/src/neuronumba/tools/filterps.py
@@ -9,6 +9,7 @@ import numpy as np
 from scipy import stats
 from enum import Enum
 from neuronumba.tools.filters import BandPassFilter
+from typing import Union
 
 class FiltPowSpetraVersion(Enum):
     v2021 = "v2021" # This is now the default one (from Irene's code)
@@ -91,7 +92,7 @@ def filt_pow_spetra(
     return PowSpect_filt_narrow
 
 def filt_pow_spetra_multiple_subjects(
-    signal: np.ndarray, 
+    signal: Union[np.ndarray, dict], 
     tr: float, 
     bpf: BandPassFilter,
     version: FiltPowSpetraVersion=FiltPowSpetraVersion.v2021

--- a/src/neuronumba/tools/matlab_tricks.py
+++ b/src/neuronumba/tools/matlab_tricks.py
@@ -2,6 +2,7 @@ import numpy as np
 import pandas as pd
 from scipy.special import erfcinv, betainc
 from scipy.stats import pearsonr
+import control
 
 # Matlab's corr2 function. Code taken from
 # https://stackoverflow.com/questions/29481518/python-equivalent-of-matlab-corr2
@@ -103,3 +104,20 @@ def reject_outliers(data, m = 3.):
     mdev = c*np.median(d)
     s = d / (mdev if mdev else 1.)
     return array_data[s < m]
+
+# Solve the Lyapunov/Sylvester equation in continuous time
+# https://python-control.readthedocs.io/en/latest/generated/control.lyap.html
+# NOTE: That it can use several implementation. The default used 'slycot', is the more similar as the one it uses
+# matlab internally, as it is using the same underlaying library. It is also faster than linalg.
+def lyap(A, Q, C=None, E=None, method='slycot'):
+    """
+    A, Q: 2D array_like
+        Input matrices for the Lyapunov or Sylvestor equation.
+    C: 2D array_like, optional
+        If present, solve the Sylvester equation.
+    E: 2D array_like, optional
+        If present, solve the generalized Lyapunov equation.
+    method: str, optional
+        Set the method used for computing the result. Current methods are ‘slycot’ and ‘scipy’.
+    """
+    return control.lyap(A, Q, C, E, method)


### PR DESCRIPTION
Several things done:

- FitGEC signal is now in (time x nodes) format and TR in ms.
- Moved other functions as static FitGEC functions
- Fixed filerps signal format and TR.
- Implemented 2 version in filterps (named: v2021, v2015 for lack of better namings). Being v2015 the original one, and now the v2021 the default one. 
- Refractored filterps functions
- Moved "lyap", the solver for Lyapunov/Sylvester equation into matlab_tricks.py
- Make default use of "slycot" in "lyap" function (closer to matlab and faster to compute). As consequence it needs to import/install _control_ and _slycot_. Scipy version can be used also if needed changing the parameter "method" to "scipy".