### PR TITLE
Move HFreq to an observable + change FDT to FdtDeco2023

### DIFF
--- a/src/neuronumba/fitting/gec/fitting_gec.py
+++ b/src/neuronumba/fitting/gec/fitting_gec.py
@@ -21,7 +21,6 @@ from scipy.linalg import expm
 
 from neuronumba.basic.attr import HasAttr, Attr
 from neuronumba.observables.linear.linearfc import LinearFC
-from neuronumba.tools import filterps
 from neuronumba.simulator.models import Model
 from neuronumba.tools.filters import BandPassFilter
 
@@ -179,31 +178,6 @@ class FitGEC(HasAttr):
                 sr[i,j] = 1/np.sqrt(abs(cov[i,i]))/np.sqrt(abs(cov[j,j]))
         return sr
 
-    @staticmethod
-    def calc_H_freq(
-        all_HC_fMRI: Union[np.ndarray, dict], 
-        tr: float, 
-        version: filterps.FiltPowSpetraVersion=filterps.FiltPowSpetraVersion.v2021
-    ):
-        """
-        Compute H freq for each node. 
-        
-        Parameters
-        ----------
-        all_HC_fMRI: The fMRI of the "health control" group. Can be given in a dictionaray format, 
-                     or in an array format (subject, time, node).
-                     NOTE: that the signals must already be filitered. 
-        tr: TR in milliseconds
-        version: Version of FiltPowSpectra to use
-
-        Returns
-        -------
-        The h frequencies for each node
-        """
-        f_diff = filterps.filt_pow_spetra_multiple_subjects(all_HC_fMRI, tr, version)
-        return 2 * np.pi * f_diff  # omega
-
-    # --------------- fit gEC
     def fitGEC(
         self, 
         timeseries: np.ndarray, 

--- a/src/neuronumba/observables/__init__.py
+++ b/src/neuronumba/observables/__init__.py
@@ -2,4 +2,5 @@ from neuronumba.observables.fc import FC
 from neuronumba.observables.ph_fcd import PhFCD
 from neuronumba.observables.turbulence import Turbulence
 from neuronumba.observables.turbulence2 import Information_cascade, Information_transfer
-from neuronumba.observables.fdt import FDT
+from neuronumba.observables.hfreq import HFreq
+from neuronumba.observables.fdt_deco2023 import FdtDeco2023

--- a/src/neuronumba/observables/fdt_deco2023.py
+++ b/src/neuronumba/observables/fdt_deco2023.py
@@ -15,7 +15,7 @@ from neuronumba.basic.attr import Attr
 from neuronumba.simulator.models import Model
 from neuronumba.observables.linear.linearfc import LinearFC
 
-class FDT(Observable):
+class FdtDeco2023(Observable):
     sigma = Attr(default=0.01)
     eff_con = Attr(default=None)
     model = Attr(default=None)

--- a/src/neuronumba/observables/hfreq.py
+++ b/src/neuronumba/observables/hfreq.py
@@ -1,0 +1,29 @@
+import numpy as np
+from neuronumba.basic.attr import Attr
+from typing import Union
+from neuronumba.observables.base_observable import Observable
+from neuronumba.tools import filterps
+
+class HFreq(Observable):
+    """
+    Observable class to compute given a group, the h-frequencies for each node
+    """
+
+    # tr in ms
+    tr = Attr(default=None)
+    # The array or dictionary of the group that the frequencies will be extracted from. 
+    # Each frmi on the array/dict should be in (time, nodes)
+    group_fmri = Attr(default=None)
+    # The version of filterps to use 
+    filterps_version = Attr(default=filterps.FiltPowSpetraVersion.v2021)
+
+    def _compute(self):
+        if not isinstance(self.tr, float):
+            raise TypeError(f'Parameter "tr" must be float, got {type(self.tr).__name__}')
+        if not isinstance(self.group_fmri, (np.ndarray, dict)):
+            raise TypeError(f'Parameter "group_fmri" must be either np.ndarray or dict, got {type(self.group_fmri).__name__}')
+        if not isinstance(self.filterps_version, filterps.FiltPowSpetraVersion):
+            raise TypeError(f'Parameter "filterps_version" must be FilterPowSpetraVersion, got {type(self.filterps_version).__name__}')
+
+        f_diff = filterps.filt_pow_spetra_multiple_subjects(self.group_fmri, self.tr, self.filterps_version)
+        return 2 * np.pi * f_diff  # omega

--- a/src/neuronumba/observables/hfreq.py
+++ b/src/neuronumba/observables/hfreq.py
@@ -18,6 +18,8 @@ class HFreq(Observable):
     filterps_version = Attr(default=filterps.FiltPowSpetraVersion.v2021)
 
     def _compute(self):
+        if isinstance(self.tr, int):
+            self.tr = float(self.tr)
         if not isinstance(self.tr, float):
             raise TypeError(f'Parameter "tr" must be float, got {type(self.tr).__name__}')
         if not isinstance(self.group_fmri, (np.ndarray, dict)):


### PR DESCRIPTION
- Computation of the h-frequencies had been moved from an static method from GEC to its own Observable class.
- Observable FDT had been renamed to FdtDeco2023 to easily differentiate to another "FDT" implementation will come. 