### PR TITLE
Numba JIT can be disable without crash

### DIFF
--- a/src/neuronumba/numba_tools/addr.py
+++ b/src/neuronumba/numba_tools/addr.py
@@ -1,6 +1,7 @@
 import numba as nb
 import numpy.typing as npt
-
+import numpy as np
+import ctypes
 
 @nb.extending.intrinsic
 def address_as_void_pointer(typingctx, src):
@@ -12,6 +13,20 @@ def address_as_void_pointer(typingctx, src):
         return builder.inttoptr(args[0], cgutils.voidptr_t)
     return sig, codegen
 
+# The idea here is to be able to disable JIT compilation on numba so we can better debug.
+# To do that we define two versions for this functions that go in-hand in code. 
+# When JIT is disabled, then the buffer can be used directly, this is why get_addr return the same
+# buffer, and create_carray does nothing more than return the "address", that it is the first value of get_addr return. 
+if nb.config.DISABLE_JIT:
+    def get_addr(a: npt.NDArray):
+        return a, a.shape, a.dtype
 
-def get_addr(a: npt.NDArray):
-    return a.ctypes.data, a.shape, a.dtype
+    def create_carray(address, shape, dtype):
+        return address
+else:
+    def get_addr(a: npt.NDArray):
+        return a.ctypes.data, a.shape, a.dtype
+    
+    @nb.njit
+    def create_carray(address: int, shape: tuple, dtype: np.dtype):
+        return nb.carray(address_as_void_pointer(address), shape, dtype=dtype)

--- a/src/neuronumba/simulator/history.py
+++ b/src/neuronumba/simulator/history.py
@@ -36,15 +36,17 @@ class HistoryDense(History):
         self.buffer = np.zeros((len(self.c_vars), self.n_time, self.n_rois))
 
     def get_numba_update(self):
-        buffer = self.buffer
+        # buffer = self.buffer
         n_cvars = self.n_cvars
         c_vars = self.c_vars
-        addr = buffer.ctypes.data
+        # addr = buffer.ctypes.data
+        b_addr, b_shape, b_dtype = addr.get_addr(self.buffer)
 
         @nb.njit(nb.void(nb.intc, nb.f8[:, :]))
         def c_update(step: nb.intc, state: NDA_f8_2d):
-            data = nb.carray(addr.address_as_void_pointer(addr), buffer.shape,
-                             dtype=buffer.dtype)
+            # data = nb.carray(addr.address_as_void_pointer(addr), buffer.shape,
+            #                  dtype=buffer.dtype)
+            data = addr.create_carray(b_addr, b_shape, b_dtype)
             for i in range(n_cvars):
                 data[i, step % self.n_time, :] = state[c_vars[i], :]
 

--- a/src/neuronumba/simulator/history.py
+++ b/src/neuronumba/simulator/history.py
@@ -87,13 +87,12 @@ class HistoryNoDelays(History):
 
     def get_numba_sample(self):
         b_addr, b_shape, b_dtype = addr.get_addr(self.buffer)
-        # Uncomment this line to debug c_update()
-        # b = self.buffer
 
         # TODO: why adding the signature raises a numba warning about state_coupled being a non contiguous array?
         @nb.njit #(nb.f8[:, :](nb.intc))
         def c_sample(step: nb.intc):
-            b = nb.carray(addr.address_as_void_pointer(b_addr), b_shape, dtype=b_dtype)
+            # b = nb.carray(addr.address_as_void_pointer(b_addr), b_shape, dtype=b_dtype)
+            b = addr.create_carray(b_addr, b_shape, b_dtype)
             return b
 
         return c_sample
@@ -102,12 +101,11 @@ class HistoryNoDelays(History):
         n_cvars = self.n_cvars
         c_vars = self.c_vars
         b_addr, b_shape, b_dtype = addr.get_addr(self.buffer)
-        # Uncomment this line to debug c_update()
-        # b = self.buffer
 
         @nb.njit(nb.void(nb.intc, nb.f8[:, :]))
         def c_update(step: nb.intc, state: NDA_f8_2d):
-            b = nb.carray(addr.address_as_void_pointer(b_addr), b_shape, dtype=b_dtype)
+            # b = nb.carray(addr.address_as_void_pointer(b_addr), b_shape, dtype=b_dtype)
+            b = addr.create_carray(b_addr, b_shape, b_dtype)
             for i in range(n_cvars):
                 b[i, :] = state[c_vars[i], :]
 

--- a/src/neuronumba/simulator/monitors.py
+++ b/src/neuronumba/simulator/monitors.py
@@ -185,21 +185,25 @@ class TemporalAverage(Monitor):
         def m_sample(step, state, observed):
             # Update interim buffer
             if n_state > 0:
-                i_bnb_state = nb.carray(address_as_void_pointer(ibs_addr), ibs_shape, dtype=ibs_dtype)
+                # i_bnb_state = nb.carray(address_as_void_pointer(ibs_addr), ibs_shape, dtype=ibs_dtype)
+                i_bnb_state = addr.create_carray(ibs_addr, ibs_shape, ibs_dtype)
                 # i_bnb_state = self.i_buffer_state
                 i_bnb_state[(step - 1) % n_interim_samples] = state[state_vars, :]
                 if step % n_interim_samples == 0:
-                    bnb_state = nb.carray(address_as_void_pointer(bs_addr), bs_shape, dtype=bs_dtype)
+                    # bnb_state = nb.carray(address_as_void_pointer(bs_addr), bs_shape, dtype=bs_dtype)
+                    bnb_state = addr.create_carray(bs_addr, bs_shape, bs_dtype)
                     # bnb_state = self.buffer_state
                     i = nb.intc(step / n_interim_samples)
                     bnb_state[i, :, :] = i_bnb_state.sum(axis=0) / ibs_shape[0]
 
             if n_obs > 0:
-                i_bnb_observed = nb.carray(address_as_void_pointer(ibo_addr), ibo_shape, dtype=ibo_dtype)
+                # i_bnb_observed = nb.carray(address_as_void_pointer(ibo_addr), ibo_shape, dtype=ibo_dtype)
+                i_bnb_observed = addr.create_carray(ibo_addr, ibo_shape, ibo_dtype)
                 # i_bnb_observed = self.i_buffer_observed
                 i_bnb_observed[(step - 1) % n_interim_samples] = observed[obs_vars, :]
                 if step % n_interim_samples == 0:
-                    bnb_observed = nb.carray(address_as_void_pointer(bo_addr), bo_shape, dtype=bo_dtype)
+                    # bnb_observed = nb.carray(address_as_void_pointer(bo_addr), bo_shape, dtype=bo_dtype)
+                    bnb_observed = addr.create_carray(bo_addr, bo_shape, bo_dtype)
                     # bnb_observed = self.buffer_observed
                     i = nb.intc(step / n_interim_samples)
                     bnb_observed[i, :, :] = i_bnb_observed.sum(axis=0) / ibo_shape[0]


### PR DESCRIPTION
Fixed a crash with numba occurring when JIT is disabled. For now adapted history.py and monitors.py  that where the ones crashing when executing a Hopf simulation. Probably there is more places that should be changed. The to adapts are as follows:

```
# Previous:
# b = nb.carray(addr.address_as_void_pointer(b_addr), b_shape, dtype=b_dtype)
# New:
# b = addr.create_carray(b_addr, b_shape, b_dtype)
```

With this, at the beginig of the code, JIT can be disable (for better debuging experience) with:

```
from numba import config
config.DISABLE_JIT = True
```