### PR TITLE
Update example scripts to simplify integrator factory registrations

### DIFF
--- a/examples/papers/Deco2014/deco2014.py
+++ b/examples/papers/Deco2014/deco2014.py
@@ -17,10 +17,6 @@ from neuronumba.tools.loader import load_2d_matrix
 in_file_path = "./Data_Raw"
 out_file_path = "./Data_Produced"
 
-# Register Deco2014 model and its integrator configuration in the factories
-ModelFactory.add_model('Deco2014', lambda: Deco2014())
-IntegratorFactory.add_integrator_config('Deco2014', lambda dt: EulerStochastic(dt=dt, sigmas=np.r_[2e-4, 2e-4]))
-
 
 def load_connectivity():
     C = load_2d_matrix(os.path.join(in_file_path, 'Human_66.mat'), index='C')

--- a/examples/papers/Deco2018/deco2018.py
+++ b/examples/papers/Deco2018/deco2018.py
@@ -14,7 +14,6 @@ from global_coupling_fitting import (
 )
 from papers.Deco2018.serotonin2A import Deco2018
 from neuronumba.fitting.fic.fic import FICHerzog2022
-from neuronumba.simulator.integrators import EulerStochastic
 from neuronumba.simulator.simulator import simulate_nodelay
 from neuronumba.tools import hdf
 from neuronumba.tools.filters import BandPassFilter
@@ -25,7 +24,7 @@ out_file_path = "./Data_Produced"
 
 # Register Deco2018 model and its integrator configuration in the factories
 ModelFactory.add_model('Deco2018', lambda: Deco2018())
-IntegratorFactory.add_integrator_config('Deco2018', lambda dt: EulerStochastic(dt=dt, sigmas=np.r_[1e-3, 1e-3]))
+IntegratorFactory.add_integrator_config('Deco2018', np.r_[1e-2, 1e-2])
 
 
 SUBSAMPLE_STEP = 100


### PR DESCRIPTION
## Summary

Remove factory registrations from the Deco2014 example and simplify the Deco2018 integrator factory to pass a shared sigmas array instead of constructing an EulerStochastic instance via lambda. These changes align the examples with a revised factory interface that handles integrator construction internally.

## Commits

- `94c04a3` feat(Deco2014): update example to remove factory registrations
- `f949764` feat(Deco2018): update integrator factory to use shared sigmas dict
