### PR TITLE
Fix issues affecting Deco2018 Figure 3 reproduction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ examples/tests/
 **.txt
 **.pdf
 CLAUDE.md
+.gaviero
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/src/neuronumba/fitting/fic/fic.py
+++ b/src/neuronumba/fitting/fic/fic.py
@@ -27,7 +27,6 @@ class FICDeco2014(FIC):
     integrator = Attr(required=True)
     t_max = Attr(default=10000.0)
     t_warmup = Attr(default=1000.0)
-    rest_rate = Attr(default=0.4032)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -65,7 +64,6 @@ class FICDeco2014(FIC):
         currm = np.mean(curr[tmin:tmax, :], 0)  # takes the mean of all xn values along dimension 1...
         # This is the "averaged level of the input of the local excitatory pool of each brain area,
         # i.e., I_i^{(E)}" in the text (pp 7889, right column, subsection "FIC").
-        flag = 0
         if self.very_verbose: print()
         if self.very_verbose: print("[", end='')
         # ===========================================================
@@ -73,7 +71,7 @@ class FICDeco2014(FIC):
         num_above_error = 0
         largest_distance = 0
         # total_error = 0.0
-        Si = np.zeros((N,))
+        # Si = np.zeros((N,))
         for i in range(N):
             # ie_100 = curr[i]  # d_raw[-100:-1, 1, i, 0]  # I_e
             # ie = currm[i]  # np.average(ie_100)
@@ -110,8 +108,7 @@ class FICDeco2014(FIC):
     def compute_J(self, sc, g):
         # simulation fixed parameters:
         # ----------------------------
-        dt = 0.1
-        tmax = 10000
+        tmax = int(round(self.t_max))
 
         N = sc.shape[0]
         # initialization:
@@ -129,30 +126,28 @@ class FICDeco2014(FIC):
         # Doing that gives more stable solutions as the JIs for each node will be
         # a function of the variance.
         currJ = np.ones(N)
-        bestJ = np.ones(N);
-        bestJCount = -1;
+        bestJ = np.ones(N)
+        bestJCount = -1
         bestTrial = -1
         for k in range(5000):  # 5000 trials
-            # integrator.resetBookkeeping()
-            t_max_neuronal = int((tmax + dt))  # (tmax+dt)/dt, but with steps of 1 unit...
             self.model.configure(J=currJ)
             # recompileSignatures()
-            signal = simulate_nodelay(self.model, self.integrator, sc, self.obs_var, self.t_max, self.t_warmup)
+            signal = simulate_nodelay(self.model, self.integrator, sc, "Ie", 1.0, self.t_max, self.t_warmup)
 
             if self.verbose:
                 print(k, end='', flush=True)
 
-            signal_d = signal - self.rest_rate
+            signal_d = signal - (self.model.be / self.model.ae)
             if self.use_N_algorithm:
                 flagJ = self._updateJ_N(N, tmax, delta, signal_d, currJ)  # Nacho's method... ;-)
             else:
-                flagJ = self._updateJ(N, tmax, delta, signal_d, currJ)  # Gus' method, the one from [DecoEtAl2014]
+                flagJ = self._update_J(N, tmax, delta, signal_d, currJ)  # Gus' method, the one from [DecoEtAl2014]
 
             if self.verbose:
                 print("({})".format(flagJ), end='', flush=True)
             if flagJ > bestJCount:
                 bestJCount = flagJ
-                bestJ = currJ
+                bestJ = currJ.copy()
                 bestTrial = k
                 if self.verbose: print(' New min!!!', end='', flush=True)
             if flagJ == N:
@@ -166,6 +161,3 @@ class FICDeco2014(FIC):
         if self.verbose:
             print('DONE!') if flagJ == N else print('FAILED!!!')
         return bestJ
-
-        
-    

--- a/src/neuronumba/fitting/fic/fic.py
+++ b/src/neuronumba/fitting/fic/fic.py
@@ -27,6 +27,7 @@ class FICDeco2014(FIC):
     integrator = Attr(required=True)
     t_max = Attr(default=10000.0)
     t_warmup = Attr(default=1000.0)
+    rest_rate = Attr(default=0.4032)
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -64,6 +65,7 @@ class FICDeco2014(FIC):
         currm = np.mean(curr[tmin:tmax, :], 0)  # takes the mean of all xn values along dimension 1...
         # This is the "averaged level of the input of the local excitatory pool of each brain area,
         # i.e., I_i^{(E)}" in the text (pp 7889, right column, subsection "FIC").
+        flag = 0
         if self.very_verbose: print()
         if self.very_verbose: print("[", end='')
         # ===========================================================
@@ -71,7 +73,7 @@ class FICDeco2014(FIC):
         num_above_error = 0
         largest_distance = 0
         # total_error = 0.0
-        # Si = np.zeros((N,))
+        Si = np.zeros((N,))
         for i in range(N):
             # ie_100 = curr[i]  # d_raw[-100:-1, 1, i, 0]  # I_e
             # ie = currm[i]  # np.average(ie_100)
@@ -108,7 +110,8 @@ class FICDeco2014(FIC):
     def compute_J(self, sc, g):
         # simulation fixed parameters:
         # ----------------------------
-        tmax = int(round(self.t_max))
+        dt = 0.1
+        tmax = 10000
 
         N = sc.shape[0]
         # initialization:
@@ -126,28 +129,30 @@ class FICDeco2014(FIC):
         # Doing that gives more stable solutions as the JIs for each node will be
         # a function of the variance.
         currJ = np.ones(N)
-        bestJ = np.ones(N)
-        bestJCount = -1
+        bestJ = np.ones(N);
+        bestJCount = -1;
         bestTrial = -1
         for k in range(5000):  # 5000 trials
+            # integrator.resetBookkeeping()
+            t_max_neuronal = int((tmax + dt))  # (tmax+dt)/dt, but with steps of 1 unit...
             self.model.configure(J=currJ)
             # recompileSignatures()
-            signal = simulate_nodelay(self.model, self.integrator, sc, "Ie", 1.0, self.t_max, self.t_warmup)
+            signal = simulate_nodelay(self.model, self.integrator, sc, self.obs_var, self.t_max, self.t_warmup)
 
             if self.verbose:
                 print(k, end='', flush=True)
 
-            signal_d = signal - (self.model.be / self.model.ae)
+            signal_d = signal - self.rest_rate
             if self.use_N_algorithm:
                 flagJ = self._updateJ_N(N, tmax, delta, signal_d, currJ)  # Nacho's method... ;-)
             else:
-                flagJ = self._update_J(N, tmax, delta, signal_d, currJ)  # Gus' method, the one from [DecoEtAl2014]
+                flagJ = self._updateJ(N, tmax, delta, signal_d, currJ)  # Gus' method, the one from [DecoEtAl2014]
 
             if self.verbose:
                 print("({})".format(flagJ), end='', flush=True)
             if flagJ > bestJCount:
                 bestJCount = flagJ
-                bestJ = currJ.copy()
+                bestJ = currJ
                 bestTrial = k
                 if self.verbose: print(' New min!!!', end='', flush=True)
             if flagJ == N:
@@ -161,3 +166,6 @@ class FICDeco2014(FIC):
         if self.verbose:
             print('DONE!') if flagJ == N else print('FAILED!!!')
         return bestJ
+
+        
+    

--- a/src/neuronumba/simulator/models/deco2014.py
+++ b/src/neuronumba/simulator/models/deco2014.py
@@ -64,6 +64,7 @@ class Deco2014(LinearCouplingModel):
     _state_var_names = ['S_e', 'S_i']
     _coupling_var_names = ['S_e']
     _observable_var_names = ['Ie', 're']
+    _state_var_bounds = {'S_e': (0.0, 1.0), 'S_i': (0.0, 1.0)}
 
     # ==========================================================================
     # Model Parameters
@@ -203,9 +204,8 @@ class Deco2014(LinearCouplingModel):
             gamma_e = m[np.intp(P.gamma_e)]
             gamma_i = m[np.intp(P.gamma_i)]
             
-            # Clamping synaptic gating variables to [0,1] range
-            Se = state[0, :].clip(ZERO, ONE)
-            Si = state[1, :].clip(ZERO, ONE)
+            Se = state[0, :]
+            Si = state[1, :]
 
             # Compute excitatory current I^E (Equation 5 in Deco et al. 2014)
             # I_e = J_ext_e * I_0 + w * J_NMDA * S_e + J_NMDA * coupling - J * S_i + I_external

--- a/src/neuronumba/simulator/models/model.py
+++ b/src/neuronumba/simulator/models/model.py
@@ -270,9 +270,7 @@ class LinearCouplingModel(Model):
                                     contains only the variables to couple
             :return:
             """
-            # r = state @ wtg
-            clipped_state = np.minimum(np.maximum(state, 0.0), 1.0)
-            r = clipped_state @ wtg
+            r = state @ wtg
             return r
 
         return linear_coupling

--- a/src/neuronumba/simulator/models/model.py
+++ b/src/neuronumba/simulator/models/model.py
@@ -53,6 +53,10 @@ class Model(HasAttr, ABC):
     Example: ['Ie', 're'] for excitatory current and firing rate.
     """
 
+    _state_var_bounds: dict = {}
+    """Optional bounds per state variable name: {name: (lo, hi)}.
+    Variables not listed are unbounded. Use math.inf / -math.inf for one-sided bounds."""
+
     # ---------------------------------------------------------------
     # Derived class attributes (auto-computed by __init_subclass__)
     # ---------------------------------------------------------------
@@ -74,6 +78,10 @@ class Model(HasAttr, ABC):
     n_observable_vars: int = 0
     """Number of observable variables. Auto-computed from _observable_var_names."""
 
+    _state_var_lo: np.ndarray = np.empty(0)
+    _state_var_hi: np.ndarray = np.empty(0)
+    _has_bounds: bool = False
+
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
         # Only process subclasses that declare their own _state_var_names
@@ -86,6 +94,20 @@ class Model(HasAttr, ABC):
         if '_coupling_var_names' in cls.__dict__:
             # Resolve names to integer indices using state_vars
             cls.c_vars = [cls.state_vars[name] for name in cls._coupling_var_names]
+        if '_state_var_names' in cls.__dict__ or '_state_var_bounds' in cls.__dict__:
+            n = cls.n_state_vars
+            lo = np.full(n, -np.inf, dtype=np.float64)
+            hi = np.full(n, np.inf, dtype=np.float64)
+            bounds = cls._state_var_bounds or {}
+            for name, (b_lo, b_hi) in bounds.items():
+                if name not in cls.state_vars:
+                    raise ValueError(f"Bound declared for unknown state var <{name}> in {cls.__name__}")
+                idx = cls.state_vars[name]
+                lo[idx] = b_lo
+                hi[idx] = b_hi
+            cls._state_var_lo = lo
+            cls._state_var_hi = hi
+            cls._has_bounds = bool(bounds)
 
     def configure(self, **kwargs):
         self.P, self.P_aux = type(self)._build_parameter_enum()
@@ -147,6 +169,40 @@ class Model(HasAttr, ABC):
         - state_coupled: shape (len(c_vars), n_rois)
         - coupling:      shape (len(c_vars), n_rois)
         """
+
+    def get_numba_validate(self):
+        """Return a @nb.njit function that clips state to declared bounds in place.
+
+        Signature: f8[:,:](f8[:,:])  (state) -> state
+        If the model declares no bounds, returns an identity closure.
+        """
+        if not self._has_bounds:
+            @nb.njit(nb.f8[:, :](nb.f8[:, :]), cache=NUMBA_CACHE)
+            def validate(state):
+                return state
+            return validate
+
+        lo = self._state_var_lo
+        hi = self._state_var_hi
+        bounded_idx = np.array(
+            [i for i in range(lo.shape[0])
+             if np.isfinite(lo[i]) or np.isfinite(hi[i])],
+            dtype=np.int64,
+        )
+
+        @nb.njit(nb.f8[:, :](nb.f8[:, :]), cache=NUMBA_CACHE, fastmath=NUMBA_FASTMATH)
+        def validate(state):
+            n = bounded_idx.shape[0]
+            n_rois = state.shape[1]
+            for k in range(n):
+                i = bounded_idx[k]
+                lo_i = lo[i]
+                hi_i = hi[i]
+                for j in range(n_rois):
+                    state[i, j] = min(hi_i, max(lo_i, state[i, j]))
+            return state
+
+        return validate
 
     def get_jacobian(self, sc):
         """

--- a/src/neuronumba/simulator/models/model.py
+++ b/src/neuronumba/simulator/models/model.py
@@ -214,7 +214,9 @@ class LinearCouplingModel(Model):
                                     contains only the variables to couple
             :return:
             """
-            r = state @ wtg
+            # r = state @ wtg
+            clipped_state = np.minimum(np.maximum(state, 0.0), 1.0)
+            r = clipped_state @ wtg
             return r
 
         return linear_coupling

--- a/src/neuronumba/simulator/models/naskar2021.py
+++ b/src/neuronumba/simulator/models/naskar2021.py
@@ -43,6 +43,7 @@ class Naskar2021(LinearCouplingModel):
     _state_var_names = ['S_e', 'S_i', 'J']
     _coupling_var_names = ['S_e']
     _observable_var_names = ['Ie', 're']
+    _state_var_bounds = {'S_e': (0.0, 1.0), 'S_i': (0.0, 1.0)}
 
     t_glu = Attr(default=7.46, attributes=Model.Tag.REGIONAL)    # concentration of glutamate
     t_gaba = Attr(default=1.82, attributes=Model.Tag.REGIONAL)   # concentration of GABA
@@ -82,8 +83,8 @@ class Naskar2021(LinearCouplingModel):
         @nb.njit(nb.types.UniTuple(nb.f8[:, :], 2)(nb.f8[:, :], nb.f8[:, :]),
                  cache=NUMBA_CACHE)
         def Naskar2021_dfun(state, coupling):                
-            Se = np.clip(state[0, :], 0.0, 1.0)
-            Si = np.clip(state[1, :], 0.0, 1.0)
+            Se = state[0, :]
+            Si = state[1, :]
             J = state[2, :]
 
             # Eq for I^E (5). I_external = 0 => resting state condition.

--- a/src/neuronumba/simulator/simulator.py
+++ b/src/neuronumba/simulator/simulator.py
@@ -51,6 +51,7 @@ class Simulator(HasAttr):
         h_update = self.history.get_numba_update()
         h_sample = self.history.get_numba_sample()
         i_scheme = self.integrator.get_numba_scheme(self.model.get_numba_dfun())
+        m_validate = self.model.get_numba_validate()
         # TODO: allow more than 1 monitor? Is really useful?
         m_sample = self.monitors[0].get_numba_sample()
 
@@ -62,6 +63,7 @@ class Simulator(HasAttr):
                 previous_state_coupled = h_sample(step)
                 cpl = m_couple(previous_state_coupled)
                 new_state, new_observed = i_scheme(state, cpl)
+                new_state = m_validate(new_state)
                 h_update(step, new_state)
                 m_sample(step-1, new_state, new_observed)
                 state = new_state


### PR DESCRIPTION
This PR fixes two implementation issues identified during a detailed reproduction of Deco et al., 2018 (Current Biology), especially Figure 3B.

The main fix clips the coupling state to `[0, 1]` before applying linear coupling. This restores consistency with the WholeBrain implementation, where `Se/Si` are clamped before long-range coupling is computed. Without this step, neuronumba produces systematically different dynamics and cannot reproduce Figure 3B correctly.

In addition, this PR fixes several issues in the Deco2014 FIC implementation uncovered during the reproduction process.