### PR TITLE
Refactor state variable bounds from manual clamping to declarative method 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ examples/tests/
 **.txt
 **.pdf
 CLAUDE.md
+.gaviero
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/src/neuronumba/simulator/models/deco2014.py
+++ b/src/neuronumba/simulator/models/deco2014.py
@@ -64,6 +64,7 @@ class Deco2014(LinearCouplingModel):
     _state_var_names = ['S_e', 'S_i']
     _coupling_var_names = ['S_e']
     _observable_var_names = ['Ie', 're']
+    _state_var_bounds = {'S_e': (0.0, 1.0), 'S_i': (0.0, 1.0)}
 
     # ==========================================================================
     # Model Parameters
@@ -203,9 +204,8 @@ class Deco2014(LinearCouplingModel):
             gamma_e = m[np.intp(P.gamma_e)]
             gamma_i = m[np.intp(P.gamma_i)]
             
-            # Clamping synaptic gating variables to [0,1] range
-            Se = state[0, :].clip(ZERO, ONE)
-            Si = state[1, :].clip(ZERO, ONE)
+            Se = state[0, :]
+            Si = state[1, :]
 
             # Compute excitatory current I^E (Equation 5 in Deco et al. 2014)
             # I_e = J_ext_e * I_0 + w * J_NMDA * S_e + J_NMDA * coupling - J * S_i + I_external

--- a/src/neuronumba/simulator/models/model.py
+++ b/src/neuronumba/simulator/models/model.py
@@ -53,6 +53,10 @@ class Model(HasAttr, ABC):
     Example: ['Ie', 're'] for excitatory current and firing rate.
     """
 
+    _state_var_bounds: dict = {}
+    """Optional bounds per state variable name: {name: (lo, hi)}.
+    Variables not listed are unbounded. Use math.inf / -math.inf for one-sided bounds."""
+
     # ---------------------------------------------------------------
     # Derived class attributes (auto-computed by __init_subclass__)
     # ---------------------------------------------------------------
@@ -74,6 +78,10 @@ class Model(HasAttr, ABC):
     n_observable_vars: int = 0
     """Number of observable variables. Auto-computed from _observable_var_names."""
 
+    _state_var_lo: np.ndarray = np.empty(0)
+    _state_var_hi: np.ndarray = np.empty(0)
+    _has_bounds: bool = False
+
     def __init_subclass__(cls, **kwargs):
         super().__init_subclass__(**kwargs)
         # Only process subclasses that declare their own _state_var_names
@@ -86,6 +94,20 @@ class Model(HasAttr, ABC):
         if '_coupling_var_names' in cls.__dict__:
             # Resolve names to integer indices using state_vars
             cls.c_vars = [cls.state_vars[name] for name in cls._coupling_var_names]
+        if '_state_var_names' in cls.__dict__ or '_state_var_bounds' in cls.__dict__:
+            n = cls.n_state_vars
+            lo = np.full(n, -np.inf, dtype=np.float64)
+            hi = np.full(n, np.inf, dtype=np.float64)
+            bounds = cls._state_var_bounds or {}
+            for name, (b_lo, b_hi) in bounds.items():
+                if name not in cls.state_vars:
+                    raise ValueError(f"Bound declared for unknown state var <{name}> in {cls.__name__}")
+                idx = cls.state_vars[name]
+                lo[idx] = b_lo
+                hi[idx] = b_hi
+            cls._state_var_lo = lo
+            cls._state_var_hi = hi
+            cls._has_bounds = bool(bounds)
 
     def configure(self, **kwargs):
         self.P, self.P_aux = type(self)._build_parameter_enum()
@@ -147,6 +169,40 @@ class Model(HasAttr, ABC):
         - state_coupled: shape (len(c_vars), n_rois)
         - coupling:      shape (len(c_vars), n_rois)
         """
+
+    def get_numba_validate(self):
+        """Return a @nb.njit function that clips state to declared bounds in place.
+
+        Signature: f8[:,:](f8[:,:])  (state) -> state
+        If the model declares no bounds, returns an identity closure.
+        """
+        if not self._has_bounds:
+            @nb.njit(nb.f8[:, :](nb.f8[:, :]), cache=NUMBA_CACHE)
+            def validate(state):
+                return state
+            return validate
+
+        lo = self._state_var_lo
+        hi = self._state_var_hi
+        bounded_idx = np.array(
+            [i for i in range(lo.shape[0])
+             if np.isfinite(lo[i]) or np.isfinite(hi[i])],
+            dtype=np.int64,
+        )
+
+        @nb.njit(nb.f8[:, :](nb.f8[:, :]), cache=NUMBA_CACHE, fastmath=NUMBA_FASTMATH)
+        def validate(state):
+            n = bounded_idx.shape[0]
+            n_rois = state.shape[1]
+            for k in range(n):
+                i = bounded_idx[k]
+                lo_i = lo[i]
+                hi_i = hi[i]
+                for j in range(n_rois):
+                    state[i, j] = min(hi_i, max(lo_i, state[i, j]))
+            return state
+
+        return validate
 
     def get_jacobian(self, sc):
         """

--- a/src/neuronumba/simulator/models/naskar2021.py
+++ b/src/neuronumba/simulator/models/naskar2021.py
@@ -43,6 +43,7 @@ class Naskar2021(LinearCouplingModel):
     _state_var_names = ['S_e', 'S_i', 'J']
     _coupling_var_names = ['S_e']
     _observable_var_names = ['Ie', 're']
+    _state_var_bounds = {'S_e': (0.0, 1.0), 'S_i': (0.0, 1.0)}
 
     t_glu = Attr(default=7.46, attributes=Model.Tag.REGIONAL)    # concentration of glutamate
     t_gaba = Attr(default=1.82, attributes=Model.Tag.REGIONAL)   # concentration of GABA
@@ -82,8 +83,8 @@ class Naskar2021(LinearCouplingModel):
         @nb.njit(nb.types.UniTuple(nb.f8[:, :], 2)(nb.f8[:, :], nb.f8[:, :]),
                  cache=NUMBA_CACHE)
         def Naskar2021_dfun(state, coupling):                
-            Se = np.clip(state[0, :], 0.0, 1.0)
-            Si = np.clip(state[1, :], 0.0, 1.0)
+            Se = state[0, :]
+            Si = state[1, :]
             J = state[2, :]
 
             # Eq for I^E (5). I_external = 0 => resting state condition.

--- a/src/neuronumba/simulator/simulator.py
+++ b/src/neuronumba/simulator/simulator.py
@@ -51,6 +51,7 @@ class Simulator(HasAttr):
         h_update = self.history.get_numba_update()
         h_sample = self.history.get_numba_sample()
         i_scheme = self.integrator.get_numba_scheme(self.model.get_numba_dfun())
+        m_validate = self.model.get_numba_validate()
         # TODO: allow more than 1 monitor? Is really useful?
         m_sample = self.monitors[0].get_numba_sample()
 
@@ -62,6 +63,7 @@ class Simulator(HasAttr):
                 previous_state_coupled = h_sample(step)
                 cpl = m_couple(previous_state_coupled)
                 new_state, new_observed = i_scheme(state, cpl)
+                new_state = m_validate(new_state)
                 h_update(step, new_state)
                 m_sample(step-1, new_state, new_observed)
                 state = new_state


### PR DESCRIPTION
## Summary

State variable bounds are now declared in the model base class via a _state_var_bounds dict and validated through a numba-compiled validate function called in the simulation loop. The deco2014 and naskar2021 models were updated to use this declarative bounds mechanism instead of manually clipping state values inside their dfun. A .gaviero folder was also added to .gitignore.

## Commits

- `f84d8d4` Add .gaviero folder
- `939f66b` feat(models): update deco2014 to use bounds instead of manual clamping
- `39cc993` feat(models): update model base to support state var bounds
- `36acfbd` feat(models): update naskar2021 to use bounds instead of manual clamping
- `d297774` feat(simulator): update loop to apply model bounds validation
