### PR TITLE
Remove global tag from auto_fic and recompute_steady_state in Deco2014

### DIFF
--- a/src/neuronumba/simulator/models/deco2014.py
+++ b/src/neuronumba/simulator/models/deco2014.py
@@ -71,7 +71,7 @@ class Deco2014(LinearCouplingModel):
     # ==========================================================================
     
     # Automatic FIC computation
-    auto_fic = Attr(default=True, attributes=Model.Tag.GLOBAL,
+    auto_fic = Attr(default=True,
                    doc="Whether to automatically compute inhibitory coupling strength J using FIC")
     
     # Time constants (ms)
@@ -123,7 +123,7 @@ class Deco2014(LinearCouplingModel):
                      doc="Additional external current input (nA)")
     
     # Steady state computation options
-    recompute_steady_state = Attr(default=False, attributes=Model.Tag.GLOBAL,
+    recompute_steady_state = Attr(default=False,
                                  doc="Whether to recompute steady state values")
 
     # ==========================================================================


### PR DESCRIPTION
## Summary

The auto_fic and recompute_steady_state attributes in the Deco2014 model had their Model.Tag.GLOBAL attribute removed. This change was made to fix how these attributes are classified within the model's attribute system.

## Commits

- `058ad7e` feat(models): update deco2014 attrs to remove global tag
