### PR TITLE
Add neuromodel Qt app for building neuronumba model subclasses

### DIFF
--- a/examples/neuromodel/.gitignore
+++ b/examples/neuromodel/.gitignore
@@ -1,0 +1,3 @@
+_generated/
+__pycache__/
+*.pyc

--- a/examples/neuromodel/README.md
+++ b/examples/neuromodel/README.md
@@ -1,0 +1,115 @@
+# neuromodel — a Qt app for building neuronumba models
+
+A small PySide6 application for prototyping `neuronumba` `Model` subclasses
+without hand-editing source files. Each tab is one model under construction;
+within a tab there are sub-tabs for the model's name, its variables, its
+parameters, the equations and a simulation panel.
+
+## Run
+
+From the repository root, with `neuronumba` installed:
+
+```bash
+pip install -r examples/neuromodel/requirements.txt
+python examples/neuromodel/main.py
+```
+
+The first run JIT-compiles the generated model — expect a few seconds of delay
+on the first **Run simulation** click. Subsequent runs reuse the numba cache.
+
+## Workflow
+
+1. **Pick a template** in the toolbar (`Blank`, `Deco2014`, `Hopf`,
+   `Naskar2021`) and press *Add tab*, or *Open JSON…* to reload a previously
+   saved spec.
+2. **Model tab** — set the model name; save the spec to JSON / load JSON /
+   export the generated Python module.
+3. **Variables tab** — add or remove state variables (each row: name, initial
+   value, low/high bounds, noise sigma, "Coupled" flag) and observable
+   variables. Bounds use `inf` / `-inf` for unbounded.
+4. **Parameters tab** — add or remove parameters (name, default, tag, doc).
+   * Tag `regional` exposes the parameter as a per-ROI scalar inside the numba
+     dfun.
+   * Tag `plain` keeps the parameter as a normal Python attribute (not
+     accessible inside the equations).
+5. **Equations tab** — edit the body of the dfun in plain Python. Available
+   identifiers:
+     - state variables (`S_e`, `S_i`, …)
+     - coupling inputs (`cpl_S_e`, …)
+     - regional parameters by name
+     - `np` (NumPy)
+   You must define `d<name>` for every state variable and assign every
+   observable name. Click **Validate equations** to run a pure-Python smoke
+   test on a 2-region stub — errors are reported with Python-level messages,
+   so this is much friendlier than waiting for numba to fail.
+6. **Simulation tab** — choose the number of regions (or load a connectivity
+   matrix), `dt`, total simulation time, warm-up, sampling period, integrator,
+   global coupling `g`, and the variable to plot, then press **Run
+   simulation**.
+
+## How the generated code looks
+
+`Validate equations` is pure Python and writes nothing to disk.
+`Run simulation` (and *Export Python…*) write a real Python module that
+subclasses `LinearCouplingModel`:
+
+```python
+class Deco2014(LinearCouplingModel):
+    _state_var_names = ['S_e', 'S_i']
+    _coupling_var_names = ['S_e']
+    _observable_var_names = ['Ie', 're']
+    _state_var_bounds = {'S_e': (0.0, 1.0), 'S_i': (0.0, 1.0)}
+
+    tau_e = Attr(default=100.0, attributes=Model.Tag.REGIONAL, doc='…')
+    # … one Attr per parameter …
+
+    def initial_state(self, n_rois):
+        state = np.empty((self.n_state_vars, n_rois))
+        state[0] = 0.001
+        state[1] = 0.001
+        return state
+
+    def get_noise_template(self):
+        return np.array([0.001, 0.001])
+
+    def get_numba_dfun(self):
+        m = self.m.copy(); P = self.P
+
+        @nb.njit(nb.types.UniTuple(nb.f8[:, :], 2)(nb.f8[:, :], nb.f8[:, :]),
+                 cache=NUMBA_CACHE, fastmath=NUMBA_FASTMATH, nogil=NUMBA_NOGIL)
+        def Deco2014_dfun(state, coupling):
+            S_e = state[0, :]
+            S_i = state[1, :]
+            cpl_S_e = coupling[0, :]
+            tau_e = m[np.intp(P.tau_e)]
+            # … etc …
+
+            # equations from the editor go here, indented to match …
+            dS_e = -S_e / tau_e + gamma_e * (1.0 - S_e) * re
+            dS_i = -S_i / tau_i + gamma_i * ri
+
+            return np.stack((dS_e, dS_i)), np.stack((Ie, re))
+
+        return Deco2014_dfun
+```
+
+`Run simulation` writes the file under
+`examples/neuromodel/_generated/_gen_<Name>_<hash>.py`, imports it via
+`importlib.util.spec_from_file_location`, and runs the standard neuronumba
+`Simulator`. Numba `cache`, `fastmath` and `nogil` flags are honoured (see
+`neuronumba.numba_tools.config`). The directory is excluded from git via
+`.gitignore` and can be deleted at any time.
+
+## Limitations of v1
+
+- All generated models subclass `LinearCouplingModel` (linear coupling
+  `g * W.T @ state`). Models with non-linear coupling (the real Hopf, for
+  example) can be approximated; for an exact reproduction, export the Python
+  file and override `get_numba_coupling()`.
+- Parameter values are single floats that broadcast across regions. For
+  per-ROI heterogeneity, load the JSON and set per-region arrays
+  programmatically, or edit the exported `.py`.
+- Connectivity tract lengths are random — the simulation uses
+  `HistoryNoDelays`, so axonal delays are not modelled in this app.
+- Only one observable variable can be plotted at a time (the underlying
+  simulator currently supports a single monitor).

--- a/examples/neuromodel/app.py
+++ b/examples/neuromodel/app.py
@@ -1,0 +1,97 @@
+"""Main window with one tab per model under construction."""
+from __future__ import annotations
+
+import sys
+
+from PySide6.QtGui import QAction, QKeySequence
+from PySide6.QtWidgets import (
+    QApplication, QComboBox, QFileDialog, QLabel, QMainWindow, QMessageBox,
+    QPushButton, QTabWidget, QToolBar,
+)
+
+from model_def import ModelDef
+from tab import ModelTab
+from templates import TEMPLATES
+
+
+class MainWindow(QMainWindow):
+    def __init__(self):
+        super().__init__()
+        self.setWindowTitle("Neuronumba — Model Builder")
+        self.resize(1320, 880)
+
+        self.tabs = QTabWidget()
+        self.tabs.setTabsClosable(True)
+        self.tabs.setMovable(True)
+        self.tabs.tabCloseRequested.connect(self._on_close_tab)
+        self.setCentralWidget(self.tabs)
+
+        tb = QToolBar()
+        tb.setMovable(False)
+        self.addToolBar(tb)
+
+        tb.addWidget(QLabel(" New tab from template: "))
+        self.tmpl_combo = QComboBox()
+        self.tmpl_combo.addItems(list(TEMPLATES.keys()))
+        self.tmpl_combo.setCurrentText("Deco2014")
+        tb.addWidget(self.tmpl_combo)
+
+        new_btn = QPushButton("Add tab")
+        new_btn.clicked.connect(self._on_new_tab)
+        tb.addWidget(new_btn)
+
+        tb.addSeparator()
+
+        open_btn = QPushButton("Open JSON…")
+        open_btn.clicked.connect(self._on_open_json)
+        tb.addWidget(open_btn)
+
+        new_action = QAction("New tab", self)
+        new_action.setShortcut(QKeySequence.StandardKey.New)
+        new_action.triggered.connect(self._on_new_tab)
+        self.addAction(new_action)
+
+        self._add_from_template("Deco2014")
+
+    def _on_new_tab(self):
+        self._add_from_template(self.tmpl_combo.currentText())
+
+    def _add_from_template(self, key: str):
+        md = TEMPLATES[key]()
+        self._add_tab(ModelTab(md), md.name)
+
+    def _add_tab(self, tab: ModelTab, label: str):
+        idx = self.tabs.addTab(tab, label)
+        self.tabs.setCurrentIndex(idx)
+        tab.name_edit.textChanged.connect(lambda txt, t=tab: self._rename_tab(t, txt))
+
+    def _rename_tab(self, tab: ModelTab, text: str):
+        idx = self.tabs.indexOf(tab)
+        if idx >= 0:
+            self.tabs.setTabText(idx, text or "Untitled")
+
+    def _on_close_tab(self, index: int):
+        if self.tabs.count() <= 1:
+            return
+        widget = self.tabs.widget(index)
+        self.tabs.removeTab(index)
+        widget.deleteLater()
+
+    def _on_open_json(self):
+        path, _ = QFileDialog.getOpenFileName(self, "Open model JSON", "", "JSON (*.json)")
+        if not path:
+            return
+        try:
+            with open(path) as f:
+                md = ModelDef.from_json(f.read())
+        except Exception as e:
+            QMessageBox.warning(self, "Open failed", str(e))
+            return
+        self._add_tab(ModelTab(md), md.name)
+
+
+def main():
+    app = QApplication.instance() or QApplication(sys.argv)
+    w = MainWindow()
+    w.show()
+    sys.exit(app.exec())

--- a/examples/neuromodel/builder.py
+++ b/examples/neuromodel/builder.py
@@ -1,0 +1,343 @@
+"""Generate runtime neuronumba Model subclasses from a ModelDef.
+
+Two entry points:
+
+- ``validate_equations(md)``: pure-Python smoke test (no numba, no neuronumba).
+  Runs the equation body on tiny stub arrays and checks that every required
+  ``d<state>`` and observable name was assigned with the right shape.
+- ``load_model_class(md)``: writes a real ``.py`` under ``_generated/`` and
+  imports it, returning the generated ``Model`` subclass. The file path is
+  content-hashed so numba's cache works normally.
+"""
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import keyword
+import math
+import textwrap
+from pathlib import Path
+
+import numpy as np
+
+from model_def import ModelDef
+
+
+_CACHE_DIR = Path(__file__).parent / "_generated"
+_INDENT_BODY = " " * 12   # def fn(...) inside def get_numba_dfun() inside class
+
+_RESERVED_NAMES = frozenset({
+    # Set by Model / LinearCouplingModel / generated code:
+    "weights", "weights_t", "n_rois", "g", "m", "m_aux", "P", "P_aux",
+    # Used as identifiers inside the generated body:
+    "np", "nb", "self", "state", "coupling",
+})
+
+
+def _is_valid_identifier(s: str) -> bool:
+    return s.isidentifier() and not keyword.iskeyword(s)
+
+
+def _fmt_float(v: float) -> str:
+    if math.isinf(v):
+        return "math.inf" if v > 0 else "-math.inf"
+    return repr(float(v))
+
+
+def _sanitize_class_name(name: str) -> str:
+    s = "".join(c if c.isalnum() else "_" for c in name) or "MyModel"
+    if s[0].isdigit():
+        s = "M_" + s
+    return s
+
+
+def _check_names(md: ModelDef) -> str | None:
+    state_names = [v.name for v in md.state_vars]
+    obs_names = [o.name for o in md.observable_vars]
+    param_names = [p.name for p in md.params]
+    dep_names = [d.name for d in md.dependants]
+    all_names = state_names + obs_names + param_names + dep_names
+
+    bad = [n for n in all_names if not _is_valid_identifier(n)]
+    if bad:
+        return f"Invalid Python identifier(s): {', '.join(bad)}"
+
+    clashes = [n for n in all_names if n in _RESERVED_NAMES]
+    if clashes:
+        return (
+            f"Reserved name(s) used: {', '.join(sorted(set(clashes)))} — "
+            "these are set by neuronumba or the generated code."
+        )
+
+    seen: set[str] = set()
+    for n in all_names:
+        if n in seen:
+            return f"Duplicate name across state/observable/param/dependant: {n!r}"
+        seen.add(n)
+
+    if not state_names:
+        return "At least one state variable is required."
+    return None
+
+
+def validate_equations(md: ModelDef, n_rois: int = 2) -> tuple[bool, str]:
+    """Run the equation body as plain Python on stub arrays. No numba."""
+    err = _check_names(md)
+    if err:
+        return False, err
+
+    namespace: dict = {"np": np}
+
+    rng = np.random.default_rng(0)
+    stub_weights = rng.uniform(0.0, 1.0, size=(n_rois, n_rois))
+    np.fill_diagonal(stub_weights, 0.0)
+    namespace["weights"] = stub_weights
+    namespace["n_rois"] = n_rois
+    namespace["g"] = 1.0
+
+    for p in md.params:
+        namespace[p.name] = (np.full(n_rois, p.default)
+                             if p.tag == "regional" else p.default)
+
+    for dep in md.dependants:
+        try:
+            dep_code = compile(dep.formula or "pass", f"<dependant:{dep.name}>", "exec")
+        except SyntaxError as e:
+            return False, f"Dependant {dep.name!r} syntax error on line {e.lineno}: {e.msg}"
+        try:
+            exec(dep_code, namespace)
+        except Exception as e:
+            return False, f"Dependant {dep.name!r}: {type(e).__name__}: {e}"
+        if dep.name not in namespace:
+            return False, (
+                f"Dependant {dep.name!r}: formula did not assign to {dep.name!r}."
+            )
+
+    for v in md.state_vars:
+        namespace[v.name] = np.full(n_rois, v.initial)
+    for name in md.coupling_var_names:
+        namespace[f"cpl_{name}"] = np.zeros(n_rois)
+
+    try:
+        code = compile(md.equations or "pass", "<equations>", "exec")
+    except SyntaxError as e:
+        return False, f"Syntax error on line {e.lineno}: {e.msg}"
+
+    try:
+        exec(code, namespace)
+    except Exception as e:  # the user's code can raise anything
+        return False, f"{type(e).__name__}: {e}"
+
+    missing_d = [f"d{v.name}" for v in md.state_vars if f"d{v.name}" not in namespace]
+    if missing_d:
+        return False, f"Missing derivative assignment(s): {', '.join(missing_d)}"
+
+    missing_obs = [o.name for o in md.observable_vars if o.name not in namespace]
+    if missing_obs:
+        return False, f"Missing observable assignment(s): {', '.join(missing_obs)}"
+
+    for v in md.state_vars:
+        arr = np.asarray(namespace[f"d{v.name}"], dtype=float)
+        if arr.shape != (n_rois,):
+            return False, (
+                f"d{v.name} has shape {arr.shape}, expected ({n_rois},) — "
+                "make sure the expression is a per-region 1-D array."
+            )
+
+    return True, (
+        f"OK — {len(md.dependants)} dependant(s), "
+        f"{len(md.state_vars)} state derivative(s) and "
+        f"{len(md.observable_vars)} observable(s) computed correctly."
+    )
+
+
+def _list_repr(items: list[str]) -> str:
+    return "[" + ", ".join(f"'{i}'" for i in items) + "]"
+
+
+def _bounds_src(md: ModelDef) -> str:
+    bounds = {v.name: (v.lo, v.hi) for v in md.state_vars if v.has_bounds}
+    if not bounds:
+        return "{}"
+    parts = ", ".join(
+        f"'{n}': ({_fmt_float(lo)}, {_fmt_float(hi)})" for n, (lo, hi) in bounds.items()
+    )
+    return "{" + parts + "}"
+
+
+def _attr_lines(md: ModelDef) -> list[str]:
+    lines: list[str] = []
+    for p in md.params:
+        tag = {
+            "regional": "Model.Tag.REGIONAL",
+            "plain": "Model.Tag.UNKNOWN",
+        }.get(p.tag, "Model.Tag.UNKNOWN")
+        doc = repr(p.doc) if p.doc else "''"
+        lines.append(
+            f"    {p.name} = Attr(default={_fmt_float(p.default)}, "
+            f"attributes={tag}, doc={doc})"
+        )
+    for d in md.dependants:
+        doc = repr(d.doc) if d.doc else "''"
+        lines.append(f"    {d.name} = Attr(dependant=True, doc={doc})")
+    return lines
+
+
+def _init_dependant_method(md: ModelDef) -> str:
+    """Return the source for ``_init_dependant`` or an empty string."""
+    if not md.dependants:
+        return ""
+    lines = [
+        "    def _init_dependant(self):",
+        "        super()._init_dependant()",
+        "        weights = self.weights",
+        "        n_rois = self.n_rois",
+        "        g = self.g",
+    ]
+    for p in md.params:
+        lines.append(f"        {p.name} = self.{p.name}")
+    for dep in md.dependants:
+        body = textwrap.dedent(dep.formula or "").strip()
+        if body:
+            lines.append(textwrap.indent(body, "        "))
+        lines.append(f"        self.{dep.name} = {dep.name}")
+    return "\n".join(lines) + "\n"
+
+
+def _dependant_capture_lines(md: ModelDef) -> list[str]:
+    return [f"        {d.name} = self.{d.name}" for d in md.dependants]
+
+
+def _unpack_lines(md: ModelDef) -> list[str]:
+    lines: list[str] = []
+    for i, v in enumerate(md.state_vars):
+        lines.append(f"{_INDENT_BODY}{v.name} = state[{i}, :]")
+    for i, name in enumerate(md.coupling_var_names):
+        lines.append(f"{_INDENT_BODY}cpl_{name} = coupling[{i}, :]")
+    for p in md.params:
+        if p.tag == "regional":
+            lines.append(f"{_INDENT_BODY}{p.name} = m[np.intp(P.{p.name})]")
+    return lines
+
+
+def _equations_src(md: ModelDef) -> str:
+    body = textwrap.dedent(md.equations).strip()
+    if not body:
+        return f"{_INDENT_BODY}pass"
+    return textwrap.indent(body, _INDENT_BODY)
+
+
+def _return_src(md: ModelDef) -> str:
+    n_state = len(md.state_vars)
+    d_names = ", ".join(f"d{v.name}" for v in md.state_vars)
+    state_expr = f"np.stack(({d_names},))" if n_state == 1 else f"np.stack(({d_names}))"
+
+    obs_count = len(md.observable_vars)
+    obs_names = ", ".join(o.name for o in md.observable_vars)
+    if obs_count == 0:
+        obs_expr = "np.empty((1, 1))"
+    elif obs_count == 1:
+        obs_expr = f"np.stack(({obs_names},))"
+    else:
+        obs_expr = f"np.stack(({obs_names}))"
+
+    return f"{_INDENT_BODY}return {state_expr}, {obs_expr}"
+
+
+def _initial_state_src(md: ModelDef) -> str:
+    lines = ["        state = np.empty((self.n_state_vars, n_rois))"]
+    for i, v in enumerate(md.state_vars):
+        lines.append(f"        state[{i}] = {_fmt_float(v.initial)}")
+    lines.append("        return state")
+    return "\n".join(lines)
+
+
+def _noise_template_src(md: ModelDef) -> str:
+    if not md.state_vars:
+        return "        return np.array([0.0])"
+    sigmas = ", ".join(_fmt_float(v.sigma) for v in md.state_vars)
+    return f"        return np.array([{sigmas}])"
+
+
+def generate_source(md: ModelDef) -> str:
+    cls_name = _sanitize_class_name(md.name)
+    state_names = [v.name for v in md.state_vars]
+    obs_names = [o.name for o in md.observable_vars]
+    coupling_names = md.coupling_var_names
+
+    attr_block = "\n".join(_attr_lines(md)) or "    pass"
+    init_dep_block = _init_dependant_method(md)
+    unpack_block = "\n".join(_unpack_lines(md))
+    eq_block = _equations_src(md)
+    return_block = _return_src(md)
+    dep_capture_block = "\n".join(_dependant_capture_lines(md))
+
+    return f'''"""Generated by examples/neuromodel — do not edit by hand."""
+from __future__ import annotations
+
+import math
+
+import numba as nb
+import numpy as np
+
+from neuronumba.basic.attr import Attr
+from neuronumba.numba_tools.config import NUMBA_CACHE, NUMBA_FASTMATH, NUMBA_NOGIL
+from neuronumba.simulator.models import LinearCouplingModel, Model
+
+
+class {cls_name}(LinearCouplingModel):
+    _state_var_names = {_list_repr(state_names)}
+    _coupling_var_names = {_list_repr(coupling_names)}
+    _observable_var_names = {_list_repr(obs_names)}
+    _state_var_bounds = {_bounds_src(md)}
+
+{attr_block}
+
+{init_dep_block}
+    def initial_state(self, n_rois):
+{_initial_state_src(md)}
+
+    def get_noise_template(self):
+{_noise_template_src(md)}
+
+    def get_numba_dfun(self):
+        m = self.m.copy()
+        P = self.P
+{dep_capture_block}
+
+        @nb.njit(nb.types.UniTuple(nb.f8[:, :], 2)(nb.f8[:, :], nb.f8[:, :]),
+                 cache=NUMBA_CACHE, fastmath=NUMBA_FASTMATH, nogil=NUMBA_NOGIL)
+        def {cls_name}_dfun(state, coupling):
+{unpack_block}
+
+{eq_block}
+
+{return_block}
+
+        return {cls_name}_dfun
+'''
+
+
+def write_module(md: ModelDef) -> tuple[Path, str]:
+    """Write the generated source to disk and return (path, class_name)."""
+    _CACHE_DIR.mkdir(parents=True, exist_ok=True)
+    init = _CACHE_DIR / "__init__.py"
+    if not init.exists():
+        init.write_text("")
+    src = generate_source(md)
+    digest = hashlib.sha1(src.encode("utf-8")).hexdigest()[:10]
+    cls_name = _sanitize_class_name(md.name)
+    path = _CACHE_DIR / f"_gen_{cls_name}_{digest}.py"
+    if not path.exists():
+        path.write_text(src)
+    return path, cls_name
+
+
+def load_model_class(md: ModelDef):
+    path, cls_name = write_module(md)
+    spec = importlib.util.spec_from_file_location(path.stem, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return getattr(module, cls_name)

--- a/examples/neuromodel/dependants_widget.py
+++ b/examples/neuromodel/dependants_widget.py
@@ -1,0 +1,186 @@
+"""Editor for dependent attributes (a la neuronumba's Attr(dependant=True)).
+
+Each dependant has a name and a Python formula evaluated at configure time,
+with access to: ``weights``, ``n_rois``, ``g``, ``np``, every regional and
+plain parameter, and every earlier dependant in the list. The formula must
+assign to a variable matching the dependant's name (e.g. for ``weights_t``
+write ``weights_t = weights.T.copy()``).
+"""
+from __future__ import annotations
+
+from PySide6.QtGui import QFontDatabase
+from PySide6.QtWidgets import (
+    QFormLayout, QFrame, QHBoxLayout, QLabel, QLineEdit, QListWidget,
+    QPlainTextEdit, QPushButton, QSplitter, QVBoxLayout, QWidget,
+)
+
+from model_def import DependantDef
+
+
+_HINT = (
+    "Dependants are values computed at <i>configure time</i> from "
+    "<code>weights</code>, <code>n_rois</code>, <code>g</code>, "
+    "<code>np</code>, the model's parameters and any earlier dependants. "
+    "Each formula must assign to a variable with the dependant's name "
+    "(e.g. for <code>weights_t</code> write "
+    "<code>weights_t = weights.T.copy()</code>). The resulting values are "
+    "stored on the model and made available inside the equation body."
+)
+
+
+class DependantsWidget(QWidget):
+    def __init__(self, deps: list[DependantDef] | None = None):
+        super().__init__()
+        self._deps: list[DependantDef] = []
+        self._suppress = False
+
+        self.listw = QListWidget()
+        self.listw.currentRowChanged.connect(self._on_select_changed)
+
+        add_btn = QPushButton("Add")
+        add_btn.clicked.connect(self._on_add)
+        rm_btn = QPushButton("Remove")
+        rm_btn.clicked.connect(self._on_remove)
+
+        list_btns = QHBoxLayout()
+        list_btns.addWidget(add_btn)
+        list_btns.addWidget(rm_btn)
+
+        left = QVBoxLayout()
+        left.addWidget(self.listw, 1)
+        left.addLayout(list_btns)
+        left_w = QWidget()
+        left_w.setLayout(left)
+
+        self.name_edit = QLineEdit()
+        self.name_edit.textChanged.connect(self._on_name_changed)
+        self.formula_edit = QPlainTextEdit()
+        mono = QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont)
+        mono.setPointSize(11)
+        self.formula_edit.setFont(mono)
+        self.formula_edit.setTabStopDistance(
+            self.formula_edit.fontMetrics().horizontalAdvance("    "))
+        self.formula_edit.textChanged.connect(self._on_formula_changed)
+        self.doc_edit = QLineEdit()
+        self.doc_edit.textChanged.connect(self._on_doc_changed)
+
+        form = QFormLayout()
+        form.addRow("Name:", self.name_edit)
+        form.addRow("Formula:", self.formula_edit)
+        form.addRow("Doc:", self.doc_edit)
+        right_w = QWidget()
+        right_w.setLayout(form)
+
+        splitter = QSplitter()
+        splitter.addWidget(left_w)
+        splitter.addWidget(right_w)
+        splitter.setStretchFactor(0, 0)
+        splitter.setStretchFactor(1, 1)
+        splitter.setSizes([220, 720])
+
+        hint = QLabel(_HINT)
+        hint.setWordWrap(True)
+        hint.setFrameShape(QFrame.Shape.NoFrame)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(hint)
+        layout.addWidget(splitter, 1)
+
+        if deps:
+            self.set_dependants(deps)
+        else:
+            self._set_editor_enabled(False)
+
+    def _set_editor_enabled(self, enabled: bool) -> None:
+        self.name_edit.setEnabled(enabled)
+        self.formula_edit.setEnabled(enabled)
+        self.doc_edit.setEnabled(enabled)
+
+    def _on_add(self) -> None:
+        d = DependantDef(name=f"d{len(self._deps)}", formula="", doc="")
+        self._deps.append(d)
+        self.listw.addItem(d.name)
+        self.listw.setCurrentRow(len(self._deps) - 1)
+
+    def _on_remove(self) -> None:
+        r = self.listw.currentRow()
+        if r < 0 or r >= len(self._deps):
+            return
+        self._deps.pop(r)
+        self.listw.takeItem(r)
+        if self._deps:
+            self.listw.setCurrentRow(min(r, len(self._deps) - 1))
+        else:
+            self._on_select_changed(-1)
+
+    def _on_select_changed(self, row: int) -> None:
+        self._suppress = True
+        try:
+            if row < 0 or row >= len(self._deps):
+                self.name_edit.setText("")
+                self.formula_edit.setPlainText("")
+                self.doc_edit.setText("")
+                self._set_editor_enabled(False)
+            else:
+                d = self._deps[row]
+                self.name_edit.setText(d.name)
+                self.formula_edit.setPlainText(d.formula)
+                self.doc_edit.setText(d.doc)
+                self._set_editor_enabled(True)
+        finally:
+            self._suppress = False
+
+    def _current_dep(self) -> DependantDef | None:
+        r = self.listw.currentRow()
+        if r < 0 or r >= len(self._deps):
+            return None
+        return self._deps[r]
+
+    def _on_name_changed(self, text: str) -> None:
+        if self._suppress:
+            return
+        d = self._current_dep()
+        if d is None:
+            return
+        d.name = text.strip()
+        item = self.listw.item(self.listw.currentRow())
+        if item is not None:
+            item.setText(d.name or "(unnamed)")
+
+    def _on_formula_changed(self) -> None:
+        if self._suppress:
+            return
+        d = self._current_dep()
+        if d is None:
+            return
+        d.formula = self.formula_edit.toPlainText()
+
+    def _on_doc_changed(self, text: str) -> None:
+        if self._suppress:
+            return
+        d = self._current_dep()
+        if d is None:
+            return
+        d.doc = text
+
+    def set_dependants(self, deps: list[DependantDef]) -> None:
+        self._suppress = True
+        try:
+            self._deps = [
+                DependantDef(name=d.name, formula=d.formula, doc=d.doc) for d in deps
+            ]
+            self.listw.clear()
+            for d in self._deps:
+                self.listw.addItem(d.name or "(unnamed)")
+        finally:
+            self._suppress = False
+        if self._deps:
+            self.listw.setCurrentRow(0)
+        else:
+            self._on_select_changed(-1)
+
+    def get_dependants(self) -> list[DependantDef]:
+        return [
+            DependantDef(name=d.name, formula=d.formula, doc=d.doc)
+            for d in self._deps
+        ]

--- a/examples/neuromodel/equations_widget.py
+++ b/examples/neuromodel/equations_widget.py
@@ -1,0 +1,92 @@
+"""Equation editor with monospace font, minimal syntax highlighting, validate."""
+from __future__ import annotations
+
+import re
+
+from PySide6.QtCore import Signal
+from PySide6.QtGui import QColor, QFont, QFontDatabase, QSyntaxHighlighter, QTextCharFormat
+from PySide6.QtWidgets import (
+    QHBoxLayout, QLabel, QPlainTextEdit, QPushButton, QVBoxLayout, QWidget,
+)
+
+
+class _Highlighter(QSyntaxHighlighter):
+    KEYWORDS = (
+        "and", "as", "assert", "async", "await", "break", "class", "continue",
+        "def", "del", "elif", "else", "except", "finally", "for", "from",
+        "global", "if", "import", "in", "is", "lambda", "nonlocal", "not", "or",
+        "pass", "raise", "return", "try", "while", "with", "yield", "True",
+        "False", "None",
+    )
+
+    def __init__(self, doc):
+        super().__init__(doc)
+        self.kw_fmt = QTextCharFormat()
+        self.kw_fmt.setForeground(QColor("#005cc5"))
+        self.kw_fmt.setFontWeight(QFont.Weight.Bold)
+
+        self.np_fmt = QTextCharFormat()
+        self.np_fmt.setForeground(QColor("#6f42c1"))
+
+        self.comment_fmt = QTextCharFormat()
+        self.comment_fmt.setForeground(QColor("#6a737d"))
+        self.comment_fmt.setFontItalic(True)
+
+        self._kw_re = re.compile(r"\b(?:" + "|".join(self.KEYWORDS) + r")\b")
+        self._np_re = re.compile(r"\bnp\.\w+\b")
+        self._cmt_re = re.compile(r"#[^\n]*")
+
+    def highlightBlock(self, text: str) -> None:
+        for m in self._kw_re.finditer(text):
+            self.setFormat(m.start(), m.end() - m.start(), self.kw_fmt)
+        for m in self._np_re.finditer(text):
+            self.setFormat(m.start(), m.end() - m.start(), self.np_fmt)
+        for m in self._cmt_re.finditer(text):
+            self.setFormat(m.start(), m.end() - m.start(), self.comment_fmt)
+
+
+class EquationsWidget(QWidget):
+    validate_requested = Signal()
+
+    def __init__(self, initial: str = ""):
+        super().__init__()
+        self.editor = QPlainTextEdit()
+        self.editor.setPlainText(initial)
+        mono = QFontDatabase.systemFont(QFontDatabase.SystemFont.FixedFont)
+        mono.setPointSize(11)
+        self.editor.setFont(mono)
+        self.editor.setTabStopDistance(self.editor.fontMetrics().horizontalAdvance("    "))
+        self._hl = _Highlighter(self.editor.document())
+
+        self.validate_btn = QPushButton("Validate equations")
+        self.validate_btn.clicked.connect(self.validate_requested.emit)
+        self.status = QLabel("")
+        self.status.setWordWrap(True)
+
+        btns = QHBoxLayout()
+        btns.addWidget(self.validate_btn)
+        btns.addStretch()
+
+        hint = QLabel(
+            "Define <code>d&lt;name&gt;</code> for every state variable and "
+            "assign every observable name. Available identifiers: state "
+            "variables (<code>S_e</code>, …), coupling inputs "
+            "(<code>cpl_S_e</code>, …), regional parameters, and <code>np</code>."
+        )
+        hint.setWordWrap(True)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(hint)
+        layout.addWidget(self.editor, 1)
+        layout.addLayout(btns)
+        layout.addWidget(self.status)
+
+    def text(self) -> str:
+        return self.editor.toPlainText()
+
+    def set_text(self, txt: str) -> None:
+        self.editor.setPlainText(txt)
+
+    def set_status(self, msg: str, ok: bool) -> None:
+        color = "#22863a" if ok else "#b31d28"
+        self.status.setText(f"<span style='color:{color}'>{msg}</span>")

--- a/examples/neuromodel/main.py
+++ b/examples/neuromodel/main.py
@@ -1,0 +1,21 @@
+"""Neuromodel — entry point.
+
+Run from the repository root:
+
+    python examples/neuromodel/main.py
+"""
+import os
+import sys
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+
+def _main() -> None:
+    from app import main
+    main()
+
+
+if __name__ == "__main__":
+    _main()

--- a/examples/neuromodel/model_def.py
+++ b/examples/neuromodel/model_def.py
@@ -1,0 +1,130 @@
+"""Pure-data structures describing a neuronumba model in progress.
+
+No Qt and no neuronumba imports here on purpose, so this module is cheap to
+import and easy to test in isolation.
+"""
+from __future__ import annotations
+
+import json
+import math
+from dataclasses import dataclass, field
+
+
+_INF_TOKENS = {"inf": math.inf, "+inf": math.inf, "-inf": -math.inf}
+
+
+def _f_to_json(v: float):
+    if math.isinf(v):
+        return "inf" if v > 0 else "-inf"
+    return v
+
+
+def _json_to_f(v, default: float) -> float:
+    if v is None:
+        return default
+    if isinstance(v, str):
+        return _INF_TOKENS.get(v.strip().lower(), default)
+    return float(v)
+
+
+@dataclass
+class ParamDef:
+    name: str
+    default: float = 0.0
+    tag: str = "regional"
+    doc: str = ""
+
+
+@dataclass
+class StateVarDef:
+    name: str
+    initial: float = 0.001
+    lo: float = -math.inf
+    hi: float = math.inf
+    sigma: float = 0.0
+    is_coupling: bool = False
+
+    @property
+    def has_bounds(self) -> bool:
+        return math.isfinite(self.lo) or math.isfinite(self.hi)
+
+
+@dataclass
+class ObservableVarDef:
+    name: str
+    doc: str = ""
+
+
+@dataclass
+class DependantDef:
+    name: str
+    formula: str = ""   # Python code; must assign to a variable named `name`
+    doc: str = ""
+
+
+@dataclass
+class ModelDef:
+    name: str = "MyModel"
+    state_vars: list[StateVarDef] = field(default_factory=list)
+    observable_vars: list[ObservableVarDef] = field(default_factory=list)
+    params: list[ParamDef] = field(default_factory=list)
+    dependants: list[DependantDef] = field(default_factory=list)
+    equations: str = ""
+
+    @property
+    def coupling_var_names(self) -> list[str]:
+        return [v.name for v in self.state_vars if v.is_coupling]
+
+    def to_dict(self) -> dict:
+        return {
+            "name": self.name,
+            "state_vars": [
+                {
+                    "name": v.name,
+                    "initial": v.initial,
+                    "lo": _f_to_json(v.lo),
+                    "hi": _f_to_json(v.hi),
+                    "sigma": v.sigma,
+                    "is_coupling": v.is_coupling,
+                }
+                for v in self.state_vars
+            ],
+            "observable_vars": [{"name": o.name, "doc": o.doc} for o in self.observable_vars],
+            "params": [
+                {"name": p.name, "default": p.default, "tag": p.tag, "doc": p.doc}
+                for p in self.params
+            ],
+            "dependants": [
+                {"name": d.name, "formula": d.formula, "doc": d.doc}
+                for d in self.dependants
+            ],
+            "equations": self.equations,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "ModelDef":
+        return cls(
+            name=d.get("name", "MyModel"),
+            state_vars=[
+                StateVarDef(
+                    name=v["name"],
+                    initial=float(v.get("initial", 0.0)),
+                    lo=_json_to_f(v.get("lo"), -math.inf),
+                    hi=_json_to_f(v.get("hi"), math.inf),
+                    sigma=float(v.get("sigma", 0.0)),
+                    is_coupling=bool(v.get("is_coupling", False)),
+                )
+                for v in d.get("state_vars", [])
+            ],
+            observable_vars=[ObservableVarDef(**o) for o in d.get("observable_vars", [])],
+            params=[ParamDef(**p) for p in d.get("params", [])],
+            dependants=[DependantDef(**dd) for dd in d.get("dependants", [])],
+            equations=d.get("equations", ""),
+        )
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict(), indent=2)
+
+    @classmethod
+    def from_json(cls, s: str) -> "ModelDef":
+        return cls.from_dict(json.loads(s))

--- a/examples/neuromodel/params_widget.py
+++ b/examples/neuromodel/params_widget.py
@@ -1,0 +1,87 @@
+"""Parameter editor: a table with Name / Default / Tag / Doc columns."""
+from __future__ import annotations
+
+from PySide6.QtWidgets import (
+    QComboBox, QHBoxLayout, QHeaderView, QPushButton, QTableWidget,
+    QTableWidgetItem, QVBoxLayout, QWidget,
+)
+
+from model_def import ParamDef
+
+
+COLUMNS = ("Name", "Default", "Tag", "Doc")
+TAG_CHOICES = ("regional", "plain")
+
+
+def _cell_text(table: QTableWidget, row: int, col: int) -> str:
+    item = table.item(row, col)
+    return item.text().strip() if item else ""
+
+
+class ParamsWidget(QWidget):
+    def __init__(self, params: list[ParamDef] | None = None):
+        super().__init__()
+        self.table = QTableWidget(0, len(COLUMNS))
+        self.table.setHorizontalHeaderLabels(COLUMNS)
+        h = self.table.horizontalHeader()
+        h.setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
+        h.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+        h.setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)
+
+        add = QPushButton("Add parameter")
+        add.clicked.connect(self._on_add)
+        rm = QPushButton("Remove selected")
+        rm.clicked.connect(self._on_remove)
+
+        btns = QHBoxLayout()
+        btns.addWidget(add)
+        btns.addWidget(rm)
+        btns.addStretch()
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self.table)
+        layout.addLayout(btns)
+
+        if params:
+            self.set_params(params)
+
+    def _on_add(self):
+        self._append(ParamDef(name=f"p{self.table.rowCount()}", default=0.0, tag="regional"))
+
+    def _on_remove(self):
+        rows = sorted({i.row() for i in self.table.selectedIndexes()}, reverse=True)
+        for r in rows:
+            self.table.removeRow(r)
+
+    def _append(self, p: ParamDef):
+        r = self.table.rowCount()
+        self.table.insertRow(r)
+        self.table.setItem(r, 0, QTableWidgetItem(p.name))
+        self.table.setItem(r, 1, QTableWidgetItem(repr(p.default)))
+        cb = QComboBox()
+        cb.addItems(TAG_CHOICES)
+        cb.setCurrentText(p.tag if p.tag in TAG_CHOICES else "regional")
+        self.table.setCellWidget(r, 2, cb)
+        self.table.setItem(r, 3, QTableWidgetItem(p.doc))
+
+    def set_params(self, params: list[ParamDef]):
+        self.table.setRowCount(0)
+        for p in params:
+            self._append(p)
+
+    def get_params(self) -> list[ParamDef]:
+        out: list[ParamDef] = []
+        for r in range(self.table.rowCount()):
+            name = _cell_text(self.table, r, 0)
+            if not name:
+                continue
+            try:
+                default = float(_cell_text(self.table, r, 1) or "0")
+            except ValueError:
+                default = 0.0
+            cb = self.table.cellWidget(r, 2)
+            tag = cb.currentText() if cb else "regional"
+            out.append(ParamDef(
+                name=name, default=default, tag=tag,
+                doc=_cell_text(self.table, r, 3)))
+        return out

--- a/examples/neuromodel/sim_widget.py
+++ b/examples/neuromodel/sim_widget.py
@@ -1,0 +1,237 @@
+"""Simulation parameter form + matplotlib plot."""
+from __future__ import annotations
+
+import numpy as np
+
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
+from matplotlib.backends.backend_qtagg import NavigationToolbar2QT
+from matplotlib.figure import Figure
+
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import (
+    QCheckBox, QComboBox, QDoubleSpinBox, QFileDialog, QFormLayout, QGroupBox,
+    QHBoxLayout, QLabel, QPushButton, QSpinBox, QVBoxLayout, QWidget,
+)
+
+
+class SimWidget(QWidget):
+    run_requested = Signal()
+
+    def __init__(self):
+        super().__init__()
+
+        self.n_rois = QSpinBox()
+        self.n_rois.setRange(1, 1024)
+        self.n_rois.setValue(4)
+
+        self.dt = QDoubleSpinBox()
+        self.dt.setDecimals(4)
+        self.dt.setRange(1e-4, 100.0)
+        self.dt.setValue(0.1)
+        self.dt.setSuffix(" ms")
+
+        self.tmax = QDoubleSpinBox()
+        self.tmax.setDecimals(1)
+        self.tmax.setRange(1.0, 1e7)
+        self.tmax.setValue(5000.0)
+        self.tmax.setSuffix(" ms")
+
+        self.twarmup = QDoubleSpinBox()
+        self.twarmup.setDecimals(1)
+        self.twarmup.setRange(0.0, 1e7)
+        self.twarmup.setValue(1000.0)
+        self.twarmup.setSuffix(" ms")
+
+        self.sampling = QDoubleSpinBox()
+        self.sampling.setDecimals(2)
+        self.sampling.setRange(0.01, 1000.0)
+        self.sampling.setValue(1.0)
+        self.sampling.setSuffix(" ms")
+
+        self.integrator = QComboBox()
+        self.integrator.addItems(["EulerDeterministic", "EulerStochastic"])
+        self.integrator.setCurrentIndex(1)
+
+        self.g = QDoubleSpinBox()
+        self.g.setDecimals(4)
+        self.g.setRange(0.0, 100.0)
+        self.g.setValue(0.0)
+
+        self.observe = QComboBox()
+
+        self.run_btn = QPushButton("Run simulation")
+        self.run_btn.clicked.connect(self.run_requested.emit)
+        self.status = QLabel("")
+        self.status.setWordWrap(True)
+
+        self._weights: np.ndarray | None = None
+        self.weights_label = QLabel("(random)")
+        load_btn = QPushButton("Load…")
+        load_btn.clicked.connect(self._on_load_weights)
+        rnd_btn = QPushButton("Random")
+        rnd_btn.clicked.connect(self._on_random_weights)
+        w_row = QHBoxLayout()
+        w_row.addWidget(self.weights_label, 1)
+        w_row.addWidget(load_btn)
+        w_row.addWidget(rnd_btn)
+        w_wrapper = QWidget()
+        w_wrapper.setLayout(w_row)
+
+        form_box = QGroupBox("Simulation parameters")
+        form = QFormLayout(form_box)
+        form.addRow("Brain regions (n_rois):", self.n_rois)
+        form.addRow("Integration step dt:", self.dt)
+        form.addRow("Total simulation time:", self.tmax)
+        form.addRow("Warm-up time (discarded):", self.twarmup)
+        form.addRow("Sampling period:", self.sampling)
+        form.addRow("Integrator:", self.integrator)
+        form.addRow("Global coupling g:", self.g)
+        form.addRow("Connectivity weights:", w_wrapper)
+        form.addRow("Variable to plot:", self.observe)
+
+        run_row = QHBoxLayout()
+        run_row.addWidget(self.run_btn)
+        run_row.addStretch()
+
+        self.figure = Figure(figsize=(6, 4), tight_layout=True)
+        self.canvas = FigureCanvas(self.figure)
+        self.toolbar = NavigationToolbar2QT(self.canvas, self)
+        self._ax = None
+
+        self.ylim_auto = QCheckBox("Auto")
+        self.ylim_auto.setChecked(True)
+        self.ylim_min = QDoubleSpinBox()
+        self.ylim_max = QDoubleSpinBox()
+        for s in (self.ylim_min, self.ylim_max):
+            s.setDecimals(4)
+            s.setRange(-1e9, 1e9)
+            s.setSingleStep(0.1)
+            s.setKeyboardTracking(False)
+            s.setEnabled(False)
+        self.ylim_auto.toggled.connect(self._on_ylim_auto)
+        self.ylim_min.valueChanged.connect(self._apply_ylim)
+        self.ylim_max.valueChanged.connect(self._apply_ylim)
+
+        ylim_row = QHBoxLayout()
+        ylim_row.addWidget(QLabel("Y axis:"))
+        ylim_row.addWidget(self.ylim_auto)
+        ylim_row.addWidget(QLabel("min"))
+        ylim_row.addWidget(self.ylim_min)
+        ylim_row.addWidget(QLabel("max"))
+        ylim_row.addWidget(self.ylim_max)
+        ylim_row.addStretch()
+
+        plot_box = QGroupBox("Time series")
+        plot_layout = QVBoxLayout(plot_box)
+        plot_layout.addWidget(self.toolbar)
+        plot_layout.addLayout(ylim_row)
+        plot_layout.addWidget(self.canvas)
+
+        left = QVBoxLayout()
+        left.addWidget(form_box)
+        left.addLayout(run_row)
+        left.addWidget(self.status)
+        left.addStretch()
+        left_w = QWidget()
+        left_w.setLayout(left)
+        left_w.setMaximumWidth(420)
+
+        layout = QHBoxLayout(self)
+        layout.addWidget(left_w)
+        layout.addWidget(plot_box, 1)
+
+    def _on_load_weights(self):
+        path, _ = QFileDialog.getOpenFileName(
+            self, "Load connectivity weights", "",
+            "Data files (*.csv *.tsv *.mat *.npy *.npz);;All files (*)")
+        if not path:
+            return
+        from neuronumba.tools.loader import load_2d_matrix
+        try:
+            w = load_2d_matrix(path)
+        except Exception as e:
+            self.set_status(f"Failed to load: {e}", ok=False)
+            return
+        if w.ndim != 2 or w.shape[0] != w.shape[1]:
+            self.set_status(f"Expected square matrix, got shape {w.shape}", ok=False)
+            return
+        self._weights = w.astype(np.float64, copy=False)
+        name = path.rsplit("/", 1)[-1]
+        self.weights_label.setText(f"{name} ({w.shape[0]}x{w.shape[0]})")
+        self.n_rois.setValue(w.shape[0])
+        self.set_status(f"Loaded weights from {name}.", ok=True)
+
+    def _on_random_weights(self):
+        self._weights = None
+        self.weights_label.setText("(random)")
+
+    def get_weights(self) -> np.ndarray:
+        if self._weights is not None:
+            return self._weights
+        n = self.n_rois.value()
+        rng = np.random.default_rng(42)
+        w = rng.uniform(0.0, 1.0, size=(n, n))
+        np.fill_diagonal(w, 0.0)
+        return w
+
+    def set_observable_choices(self, names: list[str]):
+        current = self.observe.currentText()
+        self.observe.clear()
+        self.observe.addItems(names)
+        if current in names:
+            self.observe.setCurrentText(current)
+
+    def set_status(self, msg: str, ok: bool):
+        color = "#22863a" if ok else "#b31d28"
+        self.status.setText(f"<span style='color:{color}'>{msg}</span>")
+
+    def plot(self, data: np.ndarray, sampling_ms: float, title: str):
+        self.figure.clear()
+        ax = self.figure.add_subplot(111)
+        t = np.arange(data.shape[0]) * sampling_ms / 1000.0
+        ax.plot(t, data, lw=0.8)
+        ax.set_xlabel("Time (s)")
+        ax.set_ylabel(title)
+        ax.set_title(title)
+        ax.grid(alpha=0.3)
+        self._ax = ax
+        if self.ylim_auto.isChecked():
+            self._sync_ylim_spins_from_axes()
+        else:
+            self._apply_ylim()
+        self.canvas.draw_idle()
+
+    def _sync_ylim_spins_from_axes(self) -> None:
+        if self._ax is None:
+            return
+        lo, hi = self._ax.get_ylim()
+        span = max(abs(hi - lo), 1.0)
+        step = span / 20.0
+        for s, v in ((self.ylim_min, lo), (self.ylim_max, hi)):
+            s.blockSignals(True)
+            s.setSingleStep(step)
+            s.setValue(v)
+            s.blockSignals(False)
+
+    def _on_ylim_auto(self, checked: bool) -> None:
+        self.ylim_min.setEnabled(not checked)
+        self.ylim_max.setEnabled(not checked)
+        if self._ax is None:
+            return
+        if checked:
+            self._ax.relim()
+            self._ax.autoscale(axis="y")
+            self._sync_ylim_spins_from_axes()
+        else:
+            self._apply_ylim()
+        self.canvas.draw_idle()
+
+    def _apply_ylim(self) -> None:
+        if self._ax is None or self.ylim_auto.isChecked():
+            return
+        lo = self.ylim_min.value()
+        hi = self.ylim_max.value()
+        if hi <= lo:
+            hi = lo + 1e-9
+        self._ax.set_ylim(lo, hi)
+        self.canvas.draw_idle()

--- a/examples/neuromodel/tab.py
+++ b/examples/neuromodel/tab.py
@@ -1,0 +1,231 @@
+"""One tab = one neuronumba model under construction."""
+from __future__ import annotations
+
+import time
+import traceback
+
+import numpy as np
+
+from PySide6.QtWidgets import (
+    QFileDialog, QFormLayout, QHBoxLayout, QLineEdit, QMessageBox, QPushButton,
+    QTabWidget, QVBoxLayout, QWidget,
+)
+
+from builder import generate_source, load_model_class, validate_equations
+from dependants_widget import DependantsWidget
+from equations_widget import EquationsWidget
+from model_def import ModelDef
+from params_widget import ParamsWidget
+from sim_widget import SimWidget
+from vars_widget import VarsWidget
+
+
+class ModelTab(QWidget):
+    def __init__(self, md: ModelDef):
+        super().__init__()
+
+        self.name_edit = QLineEdit(md.name)
+        meta_form = QFormLayout()
+        meta_form.addRow("Model name:", self.name_edit)
+
+        save_btn = QPushButton("Save JSON…")
+        save_btn.clicked.connect(self._on_save_json)
+        load_btn = QPushButton("Load JSON…")
+        load_btn.clicked.connect(self._on_load_json)
+        export_btn = QPushButton("Export Python…")
+        export_btn.clicked.connect(self._on_export_py)
+
+        meta_btns = QHBoxLayout()
+        meta_btns.addWidget(save_btn)
+        meta_btns.addWidget(load_btn)
+        meta_btns.addWidget(export_btn)
+        meta_btns.addStretch()
+
+        meta_widget = QWidget()
+        meta_layout = QVBoxLayout(meta_widget)
+        meta_layout.addLayout(meta_form)
+        meta_layout.addLayout(meta_btns)
+        meta_layout.addStretch()
+
+        self.params_widget = ParamsWidget(md.params)
+        self.vars_widget = VarsWidget()
+        self.vars_widget.set_state_vars(md.state_vars)
+        self.vars_widget.set_observable_vars(md.observable_vars)
+
+        self.dependants_widget = DependantsWidget(md.dependants)
+
+        self.eq_widget = EquationsWidget(md.equations)
+        self.eq_widget.validate_requested.connect(self._on_validate)
+
+        self.sim_widget = SimWidget()
+        self.sim_widget.run_requested.connect(self._on_run)
+        self.sim_widget.observe.currentTextChanged.connect(self._on_observe_changed)
+
+        self._sim_results: dict[str, np.ndarray] = {}
+        self._sim_sampling: float = 0.0
+
+        inner = QTabWidget()
+        inner.addTab(meta_widget, "Model")
+        inner.addTab(self.vars_widget, "Variables")
+        inner.addTab(self.params_widget, "Parameters")
+        inner.addTab(self.dependants_widget, "Dependants")
+        inner.addTab(self.eq_widget, "Equations")
+        inner.addTab(self.sim_widget, "Simulation")
+        inner.currentChanged.connect(lambda _: self._refresh_observe_choices())
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(inner)
+
+        self._refresh_observe_choices()
+
+    def current_def(self) -> ModelDef:
+        return ModelDef(
+            name=self.name_edit.text().strip() or "MyModel",
+            state_vars=self.vars_widget.get_state_vars(),
+            observable_vars=self.vars_widget.get_observable_vars(),
+            params=self.params_widget.get_params(),
+            dependants=self.dependants_widget.get_dependants(),
+            equations=self.eq_widget.text(),
+        )
+
+    def _refresh_observe_choices(self):
+        md = self.current_def()
+        names = [v.name for v in md.state_vars] + [o.name for o in md.observable_vars]
+        self.sim_widget.set_observable_choices(names)
+
+    def _on_save_json(self):
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Save model JSON", f"{self.name_edit.text()}.json", "JSON (*.json)")
+        if not path:
+            return
+        with open(path, "w") as f:
+            f.write(self.current_def().to_json())
+        self.eq_widget.set_status(f"Saved to {path}", ok=True)
+
+    def _on_load_json(self):
+        path, _ = QFileDialog.getOpenFileName(self, "Load model JSON", "", "JSON (*.json)")
+        if not path:
+            return
+        try:
+            with open(path) as f:
+                md = ModelDef.from_json(f.read())
+        except Exception as e:
+            QMessageBox.warning(self, "Load failed", str(e))
+            return
+        self.name_edit.setText(md.name)
+        self.vars_widget.set_state_vars(md.state_vars)
+        self.vars_widget.set_observable_vars(md.observable_vars)
+        self.params_widget.set_params(md.params)
+        self.dependants_widget.set_dependants(md.dependants)
+        self.eq_widget.set_text(md.equations)
+        self._refresh_observe_choices()
+
+    def _on_export_py(self):
+        path, _ = QFileDialog.getSaveFileName(
+            self, "Export Python module", f"{self.name_edit.text()}.py", "Python (*.py)")
+        if not path:
+            return
+        with open(path, "w") as f:
+            f.write(generate_source(self.current_def()))
+        self.eq_widget.set_status(f"Exported to {path}", ok=True)
+
+    def _on_validate(self):
+        md = self.current_def()
+        ok, msg = validate_equations(md)
+        self.eq_widget.set_status(msg, ok=ok)
+
+    def _on_run(self):
+        try:
+            self._run_simulation()
+        except Exception as e:
+            traceback.print_exc()
+            self.sim_widget.set_status(f"{type(e).__name__}: {e}", ok=False)
+
+    def _run_simulation(self):
+        md = self.current_def()
+        ok, msg = validate_equations(md)
+        if not ok:
+            self.sim_widget.set_status(f"Validate failed: {msg}", ok=False)
+            return
+
+        from neuronumba.simulator.connectivity import Connectivity
+        from neuronumba.simulator.history import HistoryNoDelays
+        from neuronumba.simulator.integrators import EulerDeterministic, EulerStochastic
+        from neuronumba.simulator.monitors import RawSubSample
+        from neuronumba.simulator.simulator import Simulator
+
+        cls = load_model_class(md)
+
+        weights = self.sim_widget.get_weights()
+        n_rois = weights.shape[0]
+        if n_rois != self.sim_widget.n_rois.value():
+            self.sim_widget.n_rois.setValue(n_rois)
+
+        dt = self.sim_widget.dt.value()
+        tmax = self.sim_widget.tmax.value()
+        twarmup = self.sim_widget.twarmup.value()
+        sampling = self.sim_widget.sampling.value()
+        g = self.sim_widget.g.value()
+        integrator_name = self.sim_widget.integrator.currentText()
+        obs_var = self.sim_widget.observe.currentText()
+        if not obs_var:
+            self.sim_widget.set_status("Pick a variable to plot first.", ok=False)
+            return
+
+        model = cls(weights=weights, g=g)
+
+        if integrator_name == "EulerDeterministic":
+            integrator = EulerDeterministic(dt=dt)
+        else:
+            sigmas = np.array([v.sigma for v in md.state_vars], dtype=np.float64)
+            integrator = EulerStochastic(dt=dt, sigmas=sigmas)
+
+        rng = np.random.default_rng(0)
+        lengths = rng.uniform(1.0, 11.0, size=(n_rois, n_rois))
+        con = Connectivity(weights=weights, lengths=lengths, speed=1.0)
+        history = HistoryNoDelays()
+        all_var_names = (
+            [v.name for v in md.state_vars]
+            + [o.name for o in md.observable_vars]
+        )
+        monitor = RawSubSample(period=sampling, monitor_vars=model.get_var_info(all_var_names))
+        sim = Simulator(connectivity=con, model=model, history=history,
+                       integrator=integrator, monitors=[monitor])
+
+        self.sim_widget.set_status(
+            f"Running {tmax + twarmup:.0f} ms on n_rois={n_rois}…", ok=True)
+        self.sim_widget.run_btn.setEnabled(False)
+        self.sim_widget.run_btn.repaint()
+        try:
+            t0 = time.perf_counter()
+            sim.run(0, twarmup + tmax)
+            elapsed = time.perf_counter() - t0
+        finally:
+            self.sim_widget.run_btn.setEnabled(True)
+
+        self._sim_results = {}
+        self._sim_sampling = sampling
+        for name in all_var_names:
+            data = monitor.data(name)
+            # RawSubSample over-allocates its buffer by one row; when n_steps
+            # is a multiple of the sampling interval (the typical case) the
+            # trailing row is never written and stays at zeros.
+            if data.shape[0] >= 2:
+                data = data[:-1]
+            from_idx = int(data.shape[0] * twarmup / (twarmup + tmax))
+            self._sim_results[name] = data[from_idx:, :].copy()
+
+        self._plot_current_var()
+        shape = self._sim_results[obs_var].shape
+        self.sim_widget.set_status(
+            f"Done: data {shape} in {elapsed:.2f}s. "
+            "Switch the dropdown to replot any variable.", ok=True)
+
+    def _on_observe_changed(self, _name: str) -> None:
+        self._plot_current_var()
+
+    def _plot_current_var(self) -> None:
+        name = self.sim_widget.observe.currentText()
+        if not name or name not in self._sim_results:
+            return
+        self.sim_widget.plot(self._sim_results[name], self._sim_sampling, name)

--- a/examples/neuromodel/templates.py
+++ b/examples/neuromodel/templates.py
@@ -1,0 +1,167 @@
+"""Built-in templates: ModelDef instances for existing neuronumba models.
+
+These are hand-transcribed equations of the actual numba dfun bodies, in the
+syntax expected by ``builder.py`` (state variables as ``S_e``, coupling inputs
+as ``cpl_S_e``, parameters as plain identifiers, ``np`` available).
+"""
+from __future__ import annotations
+
+from model_def import ModelDef, ObservableVarDef, ParamDef, StateVarDef
+
+
+def blank() -> ModelDef:
+    return ModelDef(
+        name="MyModel",
+        state_vars=[StateVarDef(name="x", initial=0.1, sigma=0.02, is_coupling=True)],
+        params=[ParamDef(name="a", default=-1.0, tag="regional", doc="Local decay rate")],
+        equations="dx = a * x + cpl_x\n",
+    )
+
+
+def deco2014() -> ModelDef:
+    eqs = """\
+# Excitatory and inhibitory currents (Deco et al. 2014, eqs. 5-6)
+Ie = Jext_e * I0 + w * J_NMDA * S_e + J_NMDA * cpl_S_e - J * S_i + I_external
+Ii = Jext_i * I0 + J_NMDA * S_e - S_i
+
+# Firing rates via sigmoid transfer functions (eqs. 7-8)
+y_e = ae * Ie - be
+denom_e = 1.0 - np.exp(-de * y_e)
+denom_e = np.where(np.abs(denom_e) < 1e-12, 1e-12, denom_e)
+re = y_e / denom_e
+
+y_i = ai * Ii - bi
+denom_i = 1.0 - np.exp(-di * y_i)
+denom_i = np.where(np.abs(denom_i) < 1e-12, 1e-12, denom_i)
+ri = y_i / denom_i
+
+# Synaptic gating derivatives (eqs. 9-10)
+dS_e = -S_e / tau_e + gamma_e * (1.0 - S_e) * re
+dS_i = -S_i / tau_i + gamma_i * ri
+"""
+    return ModelDef(
+        name="Deco2014",
+        state_vars=[
+            StateVarDef(name="S_e", initial=0.001, lo=0.0, hi=1.0, sigma=1e-3, is_coupling=True),
+            StateVarDef(name="S_i", initial=0.001, lo=0.0, hi=1.0, sigma=1e-3),
+        ],
+        observable_vars=[
+            ObservableVarDef(name="Ie", doc="Excitatory current (nA)"),
+            ObservableVarDef(name="re", doc="Excitatory firing rate (Hz)"),
+        ],
+        params=[
+            ParamDef("tau_e", 100.0, "regional", "Excitatory time constant (ms)"),
+            ParamDef("tau_i", 10.0, "regional", "Inhibitory time constant (ms)"),
+            ParamDef("gamma_e", 0.000641, "regional", "Excitatory synaptic efficacy"),
+            ParamDef("gamma_i", 0.001, "regional", "Inhibitory synaptic efficacy"),
+            ParamDef("I0", 0.382, "regional", "Overall external input (nA)"),
+            ParamDef("Jext_e", 1.0, "regional", "Excitatory external input scaling"),
+            ParamDef("Jext_i", 0.7, "regional", "Inhibitory external input scaling"),
+            ParamDef("w", 1.4, "regional", "Local recurrent excitation"),
+            ParamDef("J_NMDA", 0.15, "regional", "NMDA coupling (nA)"),
+            ParamDef("J", 1.0, "regional", "Local inhibitory coupling strength"),
+            ParamDef("ae", 310.0, "regional", "Excitatory gain"),
+            ParamDef("be", 125.0, "regional", "Excitatory threshold"),
+            ParamDef("de", 0.16, "regional", "Excitatory slope"),
+            ParamDef("ai", 615.0, "regional", "Inhibitory gain"),
+            ParamDef("bi", 177.0, "regional", "Inhibitory threshold"),
+            ParamDef("di", 0.087, "regional", "Inhibitory slope"),
+            ParamDef("I_external", 0.0, "regional", "External stimulation (nA)"),
+        ],
+        equations=eqs,
+    )
+
+
+def hopf() -> ModelDef:
+    eqs = """\
+# Squared modulus of the complex state
+r2 = x * x + y * y
+
+# Cartesian normal form of the supercritical Hopf bifurcation (Deco et al. 2017).
+# Note: cpl_x and cpl_y are the standard linear couplings g * (W.T @ state).
+# The original Hopf model uses g * (W.T @ state - sum(W,2)*state) which differs
+# by a diagonal term; for a faithful Hopf implementation, edit the exported
+# Python module and override get_numba_coupling.
+dx = (a - r2) * x - omega * y + cpl_x + I_external
+dy = (a - r2) * y + omega * x + cpl_y
+"""
+    return ModelDef(
+        name="Hopf",
+        state_vars=[
+            StateVarDef(name="x", initial=0.1, sigma=0.02, is_coupling=True),
+            StateVarDef(name="y", initial=0.1, sigma=0.02, is_coupling=True),
+        ],
+        params=[
+            ParamDef("a", -0.5, "regional", "Bifurcation parameter"),
+            ParamDef("omega", 0.3, "regional", "Angular frequency"),
+            ParamDef("I_external", 0.0, "regional", "External stimulation"),
+        ],
+        equations=eqs,
+    )
+
+
+def naskar2021() -> ModelDef:
+    eqs = """\
+# Multiscale DMF with inhibitory plasticity (Naskar et al. 2021).
+Ie = We * I0 + w * J_NMDA * S_e + J_NMDA * cpl_S_e - J * S_i + I_external
+Ii = Wi * I0 + J_NMDA * S_e - S_i
+
+y_e = M_e * (ae * Ie - be)
+denom_e = 1.0 - np.exp(-de * y_e)
+denom_e = np.where(np.abs(denom_e) < 1e-12, 1e-12, denom_e)
+re = y_e / denom_e
+
+y_i = M_i * (ai * Ii - bi)
+denom_i = 1.0 - np.exp(-di * y_i)
+denom_i = np.where(np.abs(denom_i) < 1e-12, 1e-12, denom_i)
+ri = y_i / denom_i
+
+dS_e = -S_e * B_e + alfa_e * t_glu * (1.0 - S_e) * re / 1000.0
+dS_i = -S_i * B_i + alfa_i * t_gaba * (1.0 - S_i) * ri / 1000.0
+dJ   = gamma * (ri / 1000.0) * (re - rho) / 1000.0
+"""
+    return ModelDef(
+        name="Naskar2021",
+        state_vars=[
+            StateVarDef(name="S_e", initial=0.001, lo=0.0, hi=1.0, sigma=1e-3, is_coupling=True),
+            StateVarDef(name="S_i", initial=0.001, lo=0.0, hi=1.0, sigma=1e-3),
+            StateVarDef(name="J",   initial=1.0,   sigma=0.0),
+        ],
+        observable_vars=[
+            ObservableVarDef(name="Ie", doc="Excitatory current (nA)"),
+            ObservableVarDef(name="re", doc="Excitatory firing rate (Hz)"),
+        ],
+        params=[
+            ParamDef("t_glu", 7.46, "regional", "Glutamate concentration"),
+            ParamDef("t_gaba", 1.82, "regional", "GABA concentration"),
+            ParamDef("We", 1.0, "regional"),
+            ParamDef("Wi", 0.7, "regional"),
+            ParamDef("I0", 0.382, "regional", "External input (nA)"),
+            ParamDef("w", 1.4, "regional", "Recurrent excitation"),
+            ParamDef("J_NMDA", 0.15, "regional", "NMDA coupling (nA)"),
+            ParamDef("M_e", 1.0, "regional"),
+            ParamDef("ae", 310.0, "regional"),
+            ParamDef("be", 125.0, "regional"),
+            ParamDef("de", 0.16, "regional"),
+            ParamDef("ai", 615.0, "regional"),
+            ParamDef("bi", 177.0, "regional"),
+            ParamDef("di", 0.087, "regional"),
+            ParamDef("M_i", 1.0, "regional"),
+            ParamDef("alfa_e", 0.072, "regional", "NMDA forward rate"),
+            ParamDef("alfa_i", 0.53, "regional", "GABA forward rate"),
+            ParamDef("B_e", 0.0066, "regional", "NMDA backward rate (1/ms)"),
+            ParamDef("B_i", 0.18, "regional", "GABA backward rate (1/ms)"),
+            ParamDef("gamma", 1.0, "regional", "Plasticity learning rate"),
+            ParamDef("rho", 3.0, "regional", "Target excitatory firing rate (Hz)"),
+            ParamDef("I_external", 0.0, "regional"),
+        ],
+        equations=eqs,
+    )
+
+
+TEMPLATES = {
+    "Blank": blank,
+    "Deco2014": deco2014,
+    "Hopf (linear-coupling approx.)": hopf,
+    "Naskar2021": naskar2021,
+}

--- a/examples/neuromodel/vars_widget.py
+++ b/examples/neuromodel/vars_widget.py
@@ -1,0 +1,187 @@
+"""State + observable variable editor."""
+from __future__ import annotations
+
+import math
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QGroupBox, QHBoxLayout, QHeaderView, QLabel, QPushButton, QTableWidget,
+    QTableWidgetItem, QVBoxLayout, QWidget,
+)
+
+from model_def import ObservableVarDef, StateVarDef
+
+
+STATE_COLUMNS = ("Name", "Initial", "Lo", "Hi", "Noise σ", "Coupled")
+OBS_COLUMNS = ("Name", "Doc")
+
+_NOISE_COL = 4
+_NOISE_TOOLTIP = (
+    "Standard deviation of additive Gaussian noise for this state variable.\n"
+    "Only used when the integrator is EulerStochastic (Simulation tab).\n"
+    "Set to 0 to make this variable deterministic."
+)
+
+
+def _fmt_bound(v: float) -> str:
+    if math.isinf(v):
+        return "-inf" if v < 0 else "inf"
+    return f"{v:g}"
+
+
+def _parse_bound(s: str, default: float) -> float:
+    t = s.strip().lower()
+    if t in ("", "none"):
+        return default
+    if t in ("inf", "+inf"):
+        return math.inf
+    if t == "-inf":
+        return -math.inf
+    try:
+        return float(t)
+    except ValueError:
+        return default
+
+
+def _cell_text(table: QTableWidget, row: int, col: int) -> str:
+    item = table.item(row, col)
+    return item.text().strip() if item else ""
+
+
+def _safe_float(table: QTableWidget, row: int, col: int, default: float) -> float:
+    txt = _cell_text(table, row, col)
+    try:
+        return float(txt) if txt else default
+    except ValueError:
+        return default
+
+
+class VarsWidget(QWidget):
+    def __init__(self):
+        super().__init__()
+        self.state_table = self._build_table(STATE_COLUMNS)
+        noise_header = self.state_table.horizontalHeaderItem(_NOISE_COL)
+        if noise_header is not None:
+            noise_header.setToolTip(_NOISE_TOOLTIP)
+        self.obs_table = self._build_table(OBS_COLUMNS)
+
+        layout = QVBoxLayout(self)
+        layout.addWidget(self._state_group())
+        layout.addWidget(self._obs_group())
+
+    @staticmethod
+    def _build_table(headers: tuple[str, ...]) -> QTableWidget:
+        t = QTableWidget(0, len(headers))
+        t.setHorizontalHeaderLabels(headers)
+        t.horizontalHeader().setSectionResizeMode(QHeaderView.ResizeMode.Stretch)
+        t.horizontalHeader().setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+        return t
+
+    def _state_group(self) -> QGroupBox:
+        add = QPushButton("Add state var")
+        add.clicked.connect(lambda: self._append_state(
+            StateVarDef(name=f"v{self.state_table.rowCount()}")))
+        rm = QPushButton("Remove selected")
+        rm.clicked.connect(lambda: self._remove(self.state_table))
+
+        btns = QHBoxLayout()
+        btns.addWidget(add)
+        btns.addWidget(rm)
+        btns.addStretch()
+
+        box = QGroupBox("State variables (rows = order in state array)")
+        v = QVBoxLayout(box)
+        v.addWidget(self.state_table)
+        v.addLayout(btns)
+        v.addWidget(QLabel(
+            "Bounds use 'inf' / '-inf' for unbounded. "
+            "<b>Noise σ</b> is the standard deviation of additive Gaussian "
+            "noise per variable, applied only when the integrator is "
+            "<b>EulerStochastic</b> (set σ=0 to make a variable deterministic). "
+            "<b>Coupled</b> marks which variables enter inter-region coupling."))
+        return box
+
+    def _obs_group(self) -> QGroupBox:
+        add = QPushButton("Add observable")
+        add.clicked.connect(lambda: self._append_obs(
+            ObservableVarDef(name=f"o{self.obs_table.rowCount()}")))
+        rm = QPushButton("Remove selected")
+        rm.clicked.connect(lambda: self._remove(self.obs_table))
+
+        btns = QHBoxLayout()
+        btns.addWidget(add)
+        btns.addWidget(rm)
+        btns.addStretch()
+
+        box = QGroupBox("Observable variables (computed each step, not integrated)")
+        v = QVBoxLayout(box)
+        v.addWidget(self.obs_table)
+        v.addLayout(btns)
+        return box
+
+    @staticmethod
+    def _remove(table: QTableWidget):
+        rows = sorted({i.row() for i in table.selectedIndexes()}, reverse=True)
+        for r in rows:
+            table.removeRow(r)
+
+    def _append_state(self, v: StateVarDef):
+        r = self.state_table.rowCount()
+        self.state_table.insertRow(r)
+        self.state_table.setItem(r, 0, QTableWidgetItem(v.name))
+        self.state_table.setItem(r, 1, QTableWidgetItem(f"{v.initial:g}"))
+        self.state_table.setItem(r, 2, QTableWidgetItem(_fmt_bound(v.lo)))
+        self.state_table.setItem(r, 3, QTableWidgetItem(_fmt_bound(v.hi)))
+        self.state_table.setItem(r, 4, QTableWidgetItem(f"{v.sigma:g}"))
+        chk = QTableWidgetItem()
+        chk.setFlags(
+            Qt.ItemFlag.ItemIsEnabled
+            | Qt.ItemFlag.ItemIsUserCheckable
+            | Qt.ItemFlag.ItemIsSelectable
+        )
+        chk.setCheckState(Qt.CheckState.Checked if v.is_coupling else Qt.CheckState.Unchecked)
+        chk.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.state_table.setItem(r, 5, chk)
+
+    def _append_obs(self, o: ObservableVarDef):
+        r = self.obs_table.rowCount()
+        self.obs_table.insertRow(r)
+        self.obs_table.setItem(r, 0, QTableWidgetItem(o.name))
+        self.obs_table.setItem(r, 1, QTableWidgetItem(o.doc))
+
+    def set_state_vars(self, vars_: list[StateVarDef]):
+        self.state_table.setRowCount(0)
+        for v in vars_:
+            self._append_state(v)
+
+    def set_observable_vars(self, vars_: list[ObservableVarDef]):
+        self.obs_table.setRowCount(0)
+        for v in vars_:
+            self._append_obs(v)
+
+    def get_state_vars(self) -> list[StateVarDef]:
+        out: list[StateVarDef] = []
+        for r in range(self.state_table.rowCount()):
+            name = _cell_text(self.state_table, r, 0)
+            if not name:
+                continue
+            chk = self.state_table.item(r, 5)
+            is_coupling = (chk.checkState() == Qt.CheckState.Checked) if chk else False
+            out.append(StateVarDef(
+                name=name,
+                initial=_safe_float(self.state_table, r, 1, 0.0),
+                lo=_parse_bound(_cell_text(self.state_table, r, 2), -math.inf),
+                hi=_parse_bound(_cell_text(self.state_table, r, 3), math.inf),
+                sigma=_safe_float(self.state_table, r, 4, 0.0),
+                is_coupling=is_coupling,
+            ))
+        return out
+
+    def get_observable_vars(self) -> list[ObservableVarDef]:
+        out: list[ObservableVarDef] = []
+        for r in range(self.obs_table.rowCount()):
+            name = _cell_text(self.obs_table, r, 0)
+            if not name:
+                continue
+            out.append(ObservableVarDef(name=name, doc=_cell_text(self.obs_table, r, 1)))
+        return out


### PR DESCRIPTION
## Summary

Introduces a new PySide6 desktop application under examples/neuromodel that lets users prototype neuronumba Model subclasses through a graphical interface without hand-editing source files. The app provides per-model tabs with sub-editors for state variables, parameters, dependant attributes, and equations, plus a simulation panel that generates and JIT-compiles real model code at runtime. Built-in templates for Deco2014, Hopf, and Naskar2021 are included alongside a pure-Python equation validator for faster iteration.

## Commits

- `835b143` chore(neuromodel): add gitignore for generated files and caches
- `e5c30c6` docs(neuromodel): add readme for qt model builder app
- `45f59c7` feat(neuromodel): add main window with tab-per-model ui
- `ec5af1e` feat(neuromodel): add model code generator and equation validator
- `cff4e27` feat(neuromodel): add dependant attributes editor widget
- `e28b570` feat(neuromodel): add equation editor widget with syntax highlighting
- `8b3f480` feat(neuromodel): add application entry point with path setup
- `a7ed81d` feat(neuromodel): add pure-data model definition dataclasses
- `f098262` feat(neuromodel): add parameter editor table widget
- `0c7e9b6` feat(neuromodel): add simulation form widget with matplotlib plot
- `1e55906` feat(neuromodel): add model tab widget with sub-tabs and actions
- `a359140` feat(neuromodel): add built-in model templates for neuronumba models
- `dda622f` feat(neuromodel): add state and observable variable editor widget
