### PR TITLE
Fixed a duplicate name for two different funciton bug...

### DIFF
--- a/src/neuronumba/observables/turbulence2.py
+++ b/src/neuronumba/observables/turbulence2.py
@@ -161,8 +161,8 @@ class Information_cascade(ObservableFMRI):
         for lambda_pos in range(len_lambdas-1):
             lambda_v = self.lambda_values[lambda_pos]
             lambda_v_next = self.lambda_values[lambda_pos+1]
-            cc, pp = matlab_tricks.corr2(np.squeeze(enstropys[lambda_v_next][:, 1:]).T,
-                                         np.squeeze(enstropys[lambda_v][:, :-1]).T)
+            cc, pp = matlab_tricks.corr_p(np.squeeze(enstropys[lambda_v_next][:, 1:]).T,
+                                          np.squeeze(enstropys[lambda_v][:, :-1]).T)
             TransferLambda[lambda_pos+1] = np.nanmean(np.abs(cc[pp < 0.05]))  # info flow
         InformationCascade = np.nanmean(TransferLambda[1:len_lambdas],axis=0)  # info cascade
         turbus = {f'{attrib}-{lambda_v}': turbuRes[lambda_v][attrib]

--- a/src/neuronumba/tools/filters.py
+++ b/src/neuronumba/tools/filters.py
@@ -1,5 +1,6 @@
 import numpy as np
 from scipy.signal import butter, detrend, filtfilt
+from scipy import stats
 
 from neuronumba.basic.attr import HasAttr, Attr
 
@@ -15,6 +16,7 @@ class BandPassFilter(HasAttr):
     apply_demean = Attr(default=True, required=False)
     apply_detrend = Attr(default=True, required=False)
     apply_finalDetrend = Attr(default=False, required=False)
+    apply_zscore = Attr(default=False, required=False)
 
     def filter(self, signal):
         """
@@ -39,8 +41,10 @@ class BandPassFilter(HasAttr):
                     ts[ts > 3. * np.std(ts)] = 3. * np.std(ts)  # Remove strong artefacts
                     ts[ts < -3. * np.std(ts)] = -3. * np.std(ts)  # Remove strong artefacts
 
+                ts = stats.zscore(ts) if self.apply_zscore else ts
+
                 signal_filt[:, n] = filtfilt(bfilt, afilt, ts, padlen=3 * (max(len(bfilt),
-                                                                                  len(afilt)) - 1))  # Band pass filter. padlen modified to get the same result as in Matlab
+                                                                               len(afilt)) - 1))  # Band pass filter. padlen modified to get the same result as in Matlab
 
                 signal_filt[:, n] = detrend(signal_filt[:, n]) if self.apply_finalDetrend else signal_filt[:, n]
 

--- a/src/neuronumba/tools/matlab_tricks.py
+++ b/src/neuronumba/tools/matlab_tricks.py
@@ -15,7 +15,7 @@ def corr2(a,b):
     a = a - mean2(a)
     b = b - mean2(b)
 
-    r = (a*b).sum() / np.sqrt((a*a).sum() * (b*b).sum());
+    r = (a*b).sum() / np.sqrt((a*a).sum() * (b*b).sum())
     return r
 
 
@@ -30,7 +30,7 @@ def corr(A, B):
 
 # Matlab's c,p = corr(A,B) function. Based on the code from
 # https://stackoverflow.com/questions/79040124/p-values-for-all-pairs-between-two-matrices-to-achieve-matlabs-corr-function
-def corr2(A,B):
+def corr_p(A,B):
     df1 = pd.DataFrame(A)
     df2 = pd.DataFrame(B)
 


### PR DESCRIPTION
In Matlab Tricks, there were two functions with the SAME name (corr2); I fixed the one that had a different behaviour in Matlab (now corr_p).